### PR TITLE
Add setSpatialListenersAudio REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dolby.io REST APIs
 
-This repo contains projects for the dolby.io REST [Communications](https://docs.dolby.io/interactivity/reference/authentication-api) APIs:
+This repo contains projects for the dolby.io REST [Communications](https://docs.dolby.io/communications-apis/reference/authentication-api) APIs:
 - Python wrapper for both Communications and Media APIs.
 - Command Line Interface utility.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # Dolby.io REST APIs CLI
 
-Command Line Interface utility for the dolby.io REST [Communications](https://docs.dolby.io/interactivity/reference/authentication-api) APIs.
+Command Line Interface utility for the dolby.io REST [Communications](https://docs.dolby.io/communications-apis/reference/authentication-api) APIs.
 
 ## Install this project
 

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     license='CC0 1.0 Universal',
     url='https://github.com/dolbyio-samples/dolbyio-rest-apis-client-python',
     project_urls={
-        'Documentation': 'https://docs.dolby.io/interactivity/reference',
+        'Documentation': 'https://docs.dolby.io/communications-apis/reference',
         'Source': 'https://github.com/dolbyio-samples/dolbyio-rest-apis-client-python',
         'Bug Tracker': 'https://github.com/dolbyio-samples/dolbyio-rest-apis-client-python/issues',
     },

--- a/client/README.md
+++ b/client/README.md
@@ -1,6 +1,6 @@
 # Dolby.io REST APIs
 
-Python wrapper for the dolby.io REST APIs [Communications](https://docs.dolby.io/interactivity/reference/authentication-api). All the functions are using the async pattern.
+Python wrapper for the dolby.io REST APIs [Communications](https://docs.dolby.io/communications-apis/reference/authentication-api). All the functions are using the async pattern.
 
 ## Install this project
 

--- a/client/setup.py
+++ b/client/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     license='CC0 1.0 Universal',
     url='https://github.com/dolbyio-samples/dolbyio-rest-apis-client-python',
     project_urls={
-        'Documentation': 'https://docs.dolby.io/interactivity/reference',
+        'Documentation': 'https://docs.dolby.io/communications-apis/reference',
         'Source': 'https://github.com/dolbyio-samples/dolbyio-rest-apis-client-python',
         'Bug Tracker': 'https://github.com/dolbyio-samples/dolbyio-rest-apis-client-python/issues',
     },

--- a/client/src/dolbyio_rest_apis/communications/authentication.py
+++ b/client/src/dolbyio_rest_apis/communications/authentication.py
@@ -41,7 +41,7 @@ async def get_api_access_token(
     r"""
     Gets an access token to authenticate for API calls.
 
-    See: https://docs.dolby.io/interactivity/reference/jwt
+    See: https://docs.dolby.io/communications-apis/reference/jwt
 
     Args:
         consumer_key: Your Dolby.io Consumer Key.
@@ -68,7 +68,7 @@ async def get_client_access_token(
     r"""
     Gets a client access token to authenticate a session.
 
-    See: https://docs.dolby.io/interactivity/reference/postoauthtoken-1
+    See: https://docs.dolby.io/communications-apis/reference/postoauthtoken
 
     Args:
         consumer_key: Your Dolby.io Consumer Key.
@@ -96,7 +96,7 @@ async def revoke_access_token(
     r"""
     Revokes the authentication token.
 
-    See: https://docs.dolby.io/interactivity/reference/postoauthtokenrevoke-1
+    See: https://docs.dolby.io/communications-apis/reference/postoauthtokenrevoke
 
     Args:
         consumer_key: Your Dolby.io Consumer Key.

--- a/client/src/dolbyio_rest_apis/communications/conference.py
+++ b/client/src/dolbyio_rest_apis/communications/conference.py
@@ -27,7 +27,7 @@ async def create_conference(
     r"""
     Creates a conference.
 
-    See: https://docs.dolby.io/interactivity/reference/postconferencecreate
+    See: https://docs.dolby.io/communications-apis/reference/postconferencecreate
 
     Args:
         access_token: Access token to use for authentication.
@@ -101,7 +101,7 @@ async def invite(
     for an ongoing conference. If the invite request includes participants that are already in the conference, a new
     conference access token is not generated and an invitation is not sent.
 
-    See: https://docs.dolby.io/interactivity/reference/postconferenceinvite
+    See: https://docs.dolby.io/communications-apis/reference/postconferenceinvite
 
     Args:
         access_token: Access token to use for authentication.
@@ -154,7 +154,7 @@ async def kick(
     r"""
     Kicks participants from an ongoing conference.
 
-    See: https://docs.dolby.io/interactivity/reference/postconferencekick
+    See: https://docs.dolby.io/communications-apis/reference/postconferencekick
 
     Args:
         access_token: Access token to use for authentication.
@@ -187,7 +187,7 @@ async def update_permissions(
     is sent directly to the SDK. The SDK automatically receives, stores, and manages the new token
     and a permissionsUpdated event is sent.
 
-    See: https://docs.dolby.io/interactivity/reference/postconferencepermissions
+    See: https://docs.dolby.io/communications-apis/reference/postconferencepermissions
 
     Args:
         access_token: Access token to use for authentication.
@@ -238,7 +238,7 @@ async def terminate(
     r"""
     Terminates an ongoing conference and removes all remaining participants from the conference.
 
-    See: https://docs.dolby.io/interactivity/reference/deleteconference
+    See: https://docs.dolby.io/communications-apis/reference/deleteconference
 
     Args:
         access_token: Access token to use for authentication.
@@ -264,7 +264,7 @@ async def destroy(
     r"""
     Destroys an ongoing conference and removes all remaining participants from the conference.
 
-    See: https://docs.dolby.io/interactivity/reference/postconferencedestroy
+    See: https://docs.dolby.io/communications-apis/reference/postconferencedestroy
 
     Args:
         consumer_key: Your Dolby.io Consumer Key.

--- a/client/src/dolbyio_rest_apis/communications/internal/http_context.py
+++ b/client/src/dolbyio_rest_apis/communications/internal/http_context.py
@@ -21,18 +21,20 @@ class CommunicationsHttpContext(HttpContext):
 
         self._logger = logging.getLogger(CommunicationsHttpContext.__name__)
 
-    async def requests_post(
+    async def _requests_post_put(
             self,
             access_token: str,
             url: str,
+            method: str,
             payload: Any=None,
         ) -> Any or None:
         r"""
-        Sends a POST request.
+        Sends a POST or PUT request.
 
         Args:
             access_token: The Access Token to use for authentication.
             url: Where to send the request to.
+            method: HTTP method, POST or PUT.
             payload: (Optional) Content of the request.
 
         Returns:
@@ -55,10 +57,68 @@ class CommunicationsHttpContext(HttpContext):
             payload = json.dumps(payload, indent=4)
 
         return await self._send_request(
-            method='POST',
+            method=method,
             url=url,
             headers=headers,
             data=payload,
+        )
+
+    async def requests_put(
+            self,
+            access_token: str,
+            url: str,
+            payload: Any=None,
+        ) -> Any or None:
+        r"""
+        Sends a PUT request.
+
+        Args:
+            access_token: The Access Token to use for authentication.
+            url: Where to send the request to.
+            payload: (Optional) Content of the request.
+
+        Returns:
+            The JSON response if any or None.
+
+        Raises:
+            HttpRequestError: If a client error one occurred.
+            HTTPError: If one occurred.
+        """
+
+        return await self._requests_post_put(
+            access_token=access_token,
+            url=url,
+            method='PUT',
+            payload=payload
+        )
+
+    async def requests_post(
+            self,
+            access_token: str,
+            url: str,
+            payload: Any=None,
+        ) -> Any or None:
+        r"""
+        Sends a POST request.
+
+        Args:
+            access_token: The Access Token to use for authentication.
+            url: Where to send the request to.
+            payload: (Optional) Content of the request.
+
+        Returns:
+            The JSON response if any or None.
+
+        Raises:
+            HttpRequestError: If a client error one occurred.
+            HTTPError: If one occurred.
+        """
+
+        return await self._requests_post_put(
+            access_token=access_token,
+            url=url,
+            method='POST',
+            payload=payload
         )
 
     async def requests_post_basic_auth(

--- a/client/src/dolbyio_rest_apis/communications/models.py
+++ b/client/src/dolbyio_rest_apis/communications/models.py
@@ -119,3 +119,34 @@ class RemixStatus(dict):
         self.status = get_value_or_default(self, 'status', None)
         self.region = get_value_or_default(self, 'region', None)
         self.alias = get_value_or_default(self, 'alias', None)
+
+@dataclass
+class Coordinates:
+    """Representation of a Coordinate object."""
+    x: int
+    y: int
+    z: int
+
+@dataclass
+class SpatialAudioEnvironment:
+    """
+    The spatial environment of an application,
+    so the audio renderer understands which directions the application considers
+    forward, up, and right and which units it uses for distance.
+    """
+    scale: Coordinates
+    forward: Coordinates
+    up: Coordinates
+    right: Coordinates
+
+@dataclass
+class SpatialAudioListener:
+    """Representation of the listener's audio position and direction, defined using Cartesian coordinates."""
+    position: Coordinates
+    direction: Coordinates
+
+@dataclass
+class SpatialAudioUser:
+    """Representation of the user's position, defined using Cartesian coordinates."""
+    external_id: str
+    position: Coordinates

--- a/client/src/dolbyio_rest_apis/communications/monitor/conferences.py
+++ b/client/src/dolbyio_rest_apis/communications/monitor/conferences.py
@@ -30,7 +30,7 @@ async def get_conferences(
     The summary of ongoing conferences includes the following fields in the response:
     `confId`, `alias`, `region`, `dolbyVoice`, `start`, `live`, `owner`.
 
-    See: https://docs.dolby.io/interactivity/reference/getconferences
+    See: https://docs.dolby.io/communications-apis/reference/getconferences
 
     Args:
         access_token: Access token to use for authentication.
@@ -104,7 +104,7 @@ async def get_all_conferences(
     The summary of ongoing conferences includes the following fields in the response:
     `confId`, `alias`, `region`, `dolbyVoice`, `start`, `live`, `owner`.
 
-    See: https://docs.dolby.io/interactivity/reference/getconferences
+    See: https://docs.dolby.io/communications-apis/reference/getconferences
 
     Args:
         access_token: Access token to use for authentication.
@@ -172,7 +172,7 @@ async def get_conference(
     The summary of ongoing conferences includes the following fields in the response:
     `confId`, `alias`, `region`, `dolbyVoice`, `start`, `live`, `owner`.
 
-    See: https://docs.dolby.io/interactivity/reference/getconferencesummary
+    See: https://docs.dolby.io/communications-apis/reference/getconferencesummary
 
     Args:
         access_token: Access token to use for authentication.
@@ -215,7 +215,7 @@ async def get_conference_statistics(
 
     Note: The statistics are available only for terminated conferences.
 
-    See: https://docs.dolby.io/interactivity/reference/getconferencestatistics
+    See: https://docs.dolby.io/communications-apis/reference/getconferencestatistics
 
     Args:
         access_token: Access token to use for authentication.
@@ -255,7 +255,7 @@ async def get_conference_participants(
     Get statistics and connection details of all participants in a conference.
     Optionally limit the search result with a specific time range.
 
-    See: https://docs.dolby.io/interactivity/reference/getconferenceparticipants
+    See: https://docs.dolby.io/communications-apis/reference/getconferenceparticipants
 
     Args:
         access_token: Access token to use for authentication.
@@ -315,7 +315,7 @@ async def get_all_conference_participants(
     Get statistics and connection details of all participants in a conference.
     Optionally limit the search result with a specific time range.
 
-    See: https://docs.dolby.io/interactivity/reference/getconferenceparticipants
+    See: https://docs.dolby.io/communications-apis/reference/getconferenceparticipants
 
     Args:
         access_token: Access token to use for authentication.

--- a/client/src/dolbyio_rest_apis/communications/monitor/recordings.py
+++ b/client/src/dolbyio_rest_apis/communications/monitor/recordings.py
@@ -24,7 +24,7 @@ async def get_recordings(
     This API checks only the recordings that have ended during a specific time range.
     Recordings are indexed based on the ending time.
 
-    See: https://docs.dolby.io/interactivity/reference/getrecordings
+    See: https://docs.dolby.io/communications-apis/reference/getrecordings
 
     Args:
         access_token: Access token to use for authentication.
@@ -76,7 +76,7 @@ async def get_all_recordings(
     This API checks only the recordings that have ended during a specific time range.
     Recordings are indexed based on the ending time.
 
-    See: https://docs.dolby.io/interactivity/reference/getrecordings
+    See: https://docs.dolby.io/communications-apis/reference/getrecordings
 
     Args:
         access_token: Access token to use for authentication.
@@ -131,7 +131,7 @@ async def get_recording(
     This API checks the recordings that have ended during a specific time range.
     Recordings are indexed based on the ending time.
 
-    See: https://docs.dolby.io/interactivity/reference/getconferencerecordings
+    See: https://docs.dolby.io/communications-apis/reference/getconferencerecordings
 
     Args:
         access_token: Access token to use for authentication.
@@ -184,7 +184,7 @@ async def delete_recording(
 
     Warning: After deleting the recording, it is not possible to restore the recording data.
 
-    See: https://docs.dolby.io/interactivity/reference/deleteconferencerecordings
+    See: https://docs.dolby.io/communications-apis/reference/deleteconferencerecordings
 
     Args:
         access_token: Access token to use for authentication.
@@ -213,7 +213,7 @@ async def get_dolby_voice_recordings(
     Get details of all Dolby Voice-based audio recordings, and associated split recordings,
     for a given conference and download the conference recording in the MP3 audio format.
 
-    See: https://docs.dolby.io/interactivity/reference/getconferenceaudiorecording
+    See: https://docs.dolby.io/communications-apis/reference/getconferenceaudiorecording
 
     Args:
         access_token: Access token to use for authentication.
@@ -246,9 +246,9 @@ async def download_mp4_recording(
     Download the conference recording in MP4 format
 
     Download the conference recording in the MP4 video format.
-    For more information, see the [Recording](https://docs.dolby.io/interactivity/docs/recording) document.
+    For more information, see the [Recording](https://docs.dolby.io/communications-apis/docs/guides-recording-mechanisms) document.
 
-    See: https://docs.dolby.io/interactivity/reference/getconferencemp4recording
+    See: https://docs.dolby.io/communications-apis/reference/getconferencemp4recording
 
     Args:
         access_token: Access token to use for authentication.
@@ -279,9 +279,9 @@ async def download_mp3_recording(
     Download the conference recording in MP3 format
 
     Download the conference recording in the MP3 audio format. This API is available only for non-Dolby Voice conferences.
-    For more information, see the [Recording](https://docs.dolby.io/interactivity/docs/recording) document.
+    For more information, see the [Recording](https://docs.dolby.io/communications-apis/docs/guides-recording-mechanisms) document.
 
-    See: https://docs.dolby.io/interactivity/reference/getconferencemp3recording
+    See: https://docs.dolby.io/communications-apis/reference/getconferencemp3recording
 
     Args:
         access_token: Access token to use for authentication.

--- a/client/src/dolbyio_rest_apis/communications/monitor/webhooks.py
+++ b/client/src/dolbyio_rest_apis/communications/monitor/webhooks.py
@@ -23,7 +23,7 @@ async def get_events(
     Get a list of Webhook events sent, during a specific time range.
     The list includes associated endpoint response codes and headers.
 
-    See: https://docs.dolby.io/interactivity/reference/getwebhooks
+    See: https://docs.dolby.io/communications-apis/reference/getwebhooks
 
     Args:
         access_token: Access token to use for authentication.
@@ -82,7 +82,7 @@ async def get_all_events(
     Get a list of all Webhook events sent, during a specific time range.
     The list includes associated endpoint response codes and headers.
 
-    See: https://docs.dolby.io/interactivity/reference/getwebhooks
+    See: https://docs.dolby.io/communications-apis/reference/getwebhooks
 
     Args:
         access_token: Access token to use for authentication.

--- a/client/src/dolbyio_rest_apis/communications/remix.py
+++ b/client/src/dolbyio_rest_apis/communications/remix.py
@@ -21,7 +21,7 @@ async def start(
     the current mixer layout. The `Recording.MP4.Available` event is sent if the customer has configured
     the webhook in the developer portal.
 
-    See: https://docs.dolby.io/interactivity/reference/postconferencemixstart
+    See: https://docs.dolby.io/communications-apis/reference/postconferencemixstart
 
     Args:
         access_token: Access token to use for authentication.
@@ -52,7 +52,7 @@ async def get_status(
     Get the status of a current mixing job. You must use this API if the conference is protected
     using enhanced conference access control.
 
-    See: https://docs.dolby.io/interactivity/reference/postconferenceremixstatus
+    See: https://docs.dolby.io/communications-apis/reference/postconferenceremixstatus
 
     Args:
         access_token: Access token to use for authentication.
@@ -88,7 +88,7 @@ async def start_basic_auth(
     the current mixer layout. The `Recording.MP4.Available` event is sent if the customer has configured
     the webhook in the developer portal.
 
-    See: https://docs.dolby.io/interactivity/reference/postconferencemixcreate
+    See: https://docs.dolby.io/communications-apis/reference/postconferencemixcreate
 
     Args:
         consumer_key: Your Dolby.io Consumer Key.
@@ -122,7 +122,7 @@ async def get_status_basic_auth(
     r"""
     Get the status of a current mixing job.
 
-    See: https://docs.dolby.io/interactivity/reference/postconferencemixstatus
+    See: https://docs.dolby.io/communications-apis/reference/postconferencemixstatus
 
     Args:
         consumer_key: Your Dolby.io Consumer Key.

--- a/client/src/dolbyio_rest_apis/communications/streaming.py
+++ b/client/src/dolbyio_rest_apis/communications/streaming.py
@@ -16,11 +16,11 @@ async def start_rtmp(
         rtmp_urls: List[str],
     ) -> None:
     r"""
-    Starts an RTMP live stream. Once the Dolby Interactivity API service started streaming to the target url,
-    a `Stream.Rtmp.InProgress` Webhook event will be sent. You must use this API if the conference is protected
-    using enhanced conference access control.
+    Starts the RTMP live stream for the specified conference. Once the Dolby.io Communications APIs service starts
+    streaming to the target url, a `Stream.Rtmp.InProgress` Webhook event will be sent.
+    You must use this API if the conference is protected using enhanced conference access control.
 
-    See: https://docs.dolby.io/interactivity/reference/postrtmpstart
+    See: https://docs.dolby.io/communications-apis/reference/postrtmpstart
 
     Args:
         access_token: Access token to use for authentication.
@@ -48,9 +48,10 @@ async def stop_rtmp(
         conference_id: str,
     ) -> None:
     r"""
-    Stops an RTMP stream. You must use this API if the conference is protected using enhanced conference access control.
+    Stops an RTMP stream.
+    You must use this API if the conference is protected using enhanced conference access control.
 
-    See: https://docs.dolby.io/interactivity/reference/postrtmpstop
+    See: https://docs.dolby.io/communications-apis/reference/postrtmpstop
 
     Args:
         access_token: Access token to use for authentication.
@@ -67,15 +68,16 @@ async def stop_rtmp(
             url=f'{get_api_v2_url()}/conferences/mix/{conference_id}/rtmp/stop'
         )
 
+@deprecated(reason='This API is no longer applicable for applications on the new Dolby.io Communications APIs platform.')
 async def start_hls(
         access_token: str,
         conference_id: str,
     ) -> None:
     r"""
-    Starts an HTTP Live Stream (HLS). The HLS URL is included in the Stream.Hls.InProgress Webhook event.
+    Starts an HTTP Live Stream (HLS). The HLS URL is included in the `Stream.Hls.InProgress` Webhook event.
     You must use this API if the conference is protected using enhanced conference access control.
 
-    See: https://docs.dolby.io/interactivity/reference/posthlsstart
+    See: https://docs.dolby.io/communications-apis/reference/posthlsstart
 
     Args:
         access_token: Access token to use for authentication.
@@ -92,6 +94,7 @@ async def start_hls(
             url=f'{get_api_v2_url()}/conferences/mix/{conference_id}/hls/start'
         )
 
+@deprecated(reason='This API is no longer applicable for applications on the new Dolby.io Communications APIs platform.')
 async def stop_hls(
         access_token: str,
         conference_id: str,
@@ -100,7 +103,7 @@ async def stop_hls(
     Stops an HTTP Live Stream (HLS). You must use this API if the conference is protected
     using enhanced conference access control.
 
-    See: https://docs.dolby.io/interactivity/reference/posthlsstop
+    See: https://docs.dolby.io/communications-apis/reference/posthlsstop
 
     Args:
         access_token: Access token to use for authentication.
@@ -125,10 +128,10 @@ async def start_rtmp_basic_auth(
         rtmp_urls: List[str],
     ) -> None:
     r"""
-    Starts an RTMP live stream. Once the Dolby Interactivity API service started streaming to the target url,
-    a `Stream.Rtmp.InProgress` Webhook event will be sent.
+    Starts an RTMP live stream. Once the Dolby.io Communications APIs service starts
+    streaming to the target url, a `Stream.Rtmp.InProgress` Webhook event will be sent.
 
-    See: https://docs.dolby.io/interactivity/reference/postrtmpstartv1
+    See: https://docs.dolby.io/communications-apis/reference/postrtmpstartv1
 
     Args:
         consumer_key: Your Dolby.io Consumer Key.
@@ -162,7 +165,7 @@ async def stop_rtmp_basic_auth(
     r"""
     Stops an RTMP stream.
 
-    See: https://docs.dolby.io/interactivity/reference/postrtmpstopv1
+    See: https://docs.dolby.io/communications-apis/reference/postrtmpstopv1
 
     Args:
         consumer_key: Your Dolby.io Consumer Key.
@@ -190,7 +193,7 @@ async def start_hls_basic_auth(
     r"""
     Starts an HTTP Live Stream (HLS). The HLS URL is included in the Stream.Hls.InProgress Webhook event.
 
-    See: https://docs.dolby.io/interactivity/reference/posthlsstartv1
+    See: https://docs.dolby.io/communications-apis/reference/posthlsstartv1
 
     Args:
         consumer_key: Your Dolby.io Consumer Key.
@@ -218,7 +221,7 @@ async def stop_hls_basic_auth(
     r"""
     Stops an HTTP Live Stream (HLS).
 
-    See: https://docs.dolby.io/interactivity/reference/posthlsstopv1
+    See: https://docs.dolby.io/communications-apis/reference/posthlsstopv1
 
     Args:
         consumer_key: Your Dolby.io Consumer Key.


### PR DESCRIPTION
Add support for the new [setSpatialListenersAudio](https://docs.dolby.io/communications-apis/reference/putspatiallistenersaudio) REST API.
Update the documentation links.