### PR TITLE
Version 3.6.0

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -23,12 +23,31 @@ You can change the log level by using the Python [logging](https://docs.python.o
 ```python
 import logging
 
-logging.basicConfig(level="DEBUG")
+logging.basicConfig(level='DEBUG')
+```
+
+## Authentication
+
+In order to make API calls for most operations of the **Communications APIs** and **Media APIs**, you must get an access token using this API:
+
+```python
+import asyncio
+from dolbyio_rest_apis import authentication
+
+APP_KEY = 'YOUR_APP_KEY'
+APP_SECRET = 'YOUR_APP_SECRET'
+
+loop = asyncio.get_event_loop()
+
+task = authentication.get_api_token(APP_KEY, APP_SECRET)
+at = loop.run_until_complete(task)
+
+print(f'API Token: {at.access_token}')
 ```
 
 ## Communications Examples
 
-### Authenticate
+### Get a client access token
 
 To get an access token that will be used by the client SDK for an end user to open a session against dolby.io, use the following code:
 
@@ -36,44 +55,29 @@ To get an access token that will be used by the client SDK for an end user to op
 import asyncio
 from dolbyio_rest_apis.communications import authentication
 
-APP_KEY = "YOUR_APP_KEY"
-APP_SECRET = "YOUR_APP_SECRET"
+APP_KEY = 'YOUR_APP_KEY'
+APP_SECRET = 'YOUR_APP_SECRET'
 
 loop = asyncio.get_event_loop()
+
 task = authentication.get_api_token(APP_KEY, APP_SECRET)
 at = loop.run_until_complete(task)
 
-print(f"Access Token: {at.access_token}")
+print(f'Access Token: {at.access_token}')
 ```
 
-You can write an async function like that:
+Because most of the APIs are asynchronous, you can write an async function like that:
 
 ```python
 from dolbyio_rest_apis.communications import authentication
 
-APP_KEY = "YOUR_APP_KEY"
-APP_SECRET = "YOUR_APP_SECRET"
+APP_KEY = 'YOUR_APP_KEY'
+APP_SECRET = 'YOUR_APP_SECRET'
 
 async def get_client_access_token():
     at = await authentication.get_client_access_token(APP_KEY, APP_SECRET)
-    print(f"Access Token: {at.access_token}")
+    print(f'Access Token: {at.access_token}')
 
-```
-
-To get an access token that will be used by your server to perform backend operations like creating a conference, use the following code.
-
-```python
-import asyncio
-from dolbyio_rest_apis.communications import authentication
-
-APP_KEY = "YOUR_APP_KEY"
-APP_SECRET = "YOUR_APP_SECRET"
-
-loop = asyncio.get_event_loop()
-task = authentication.get_api_access_token(APP_KEY, APP_SECRET)
-at = loop.run_until_complete(task)
-
-print(f"Access Token: {at.access_token}")
 ```
 
 ### Create a conference
@@ -82,21 +86,29 @@ To create a Dolby Voice conference, you first must retrieve an API Access Token,
 
 ```python
 import asyncio
+from dolbyio_rest_apis import authentication
 from dolbyio_rest_apis.communications import conference
 from dolbyio_rest_apis.communications.models import Participant, Permission, VideoCodec
 
-access_token = "" # Retrieve an API Access Token
-owner_id = "" # Identifier of the owner of the conference
-alias = "" # Conference alias
+APP_KEY = 'YOUR_APP_KEY'
+APP_SECRET = 'YOUR_APP_SECRET'
+
+owner_id = '' # Identifier of the owner of the conference
+alias = '' # Conference alias
 
 participants = [
-    Participant("hostA", [Permission.JOIN, Permission.SEND_AUDIO, Permission.SEND_VIDEO], notify=True),
-    Participant("listener1", [Permission.JOIN], notify=False),
+    Participant('hostA', [Permission.JOIN, Permission.SEND_AUDIO, Permission.SEND_VIDEO], notify=True),
+    Participant('listener1', [Permission.JOIN], notify=False),
 ]
 
 loop = asyncio.get_event_loop()
+
+# Request an API token
+task = authentication.get_api_token(APP_KEY, APP_SECRET)
+at = loop.run_until_complete(task)
+
 task = conference.create_conference(
-    access_token,
+    at.access_token,
     owner_id,
     alias,
     video_codec=VideoCodec.VP8,
@@ -104,7 +116,7 @@ task = conference.create_conference(
 )
 conf = loop.run_until_complete(task)
 
-print(f"Conference created: {conf.id}")
+print(f'Conference created: {conf.id}')
 ```
 
 ## Real-time Streaming Examples
@@ -116,13 +128,14 @@ import asyncio
 from dolbyio_rest_apis.streaming import publish_token
 from dolbyio_rest_apis.streaming.models.publish_token import CreatePublishToken, CreateUpdatePublishTokenStream
 
-api_secret = "" # Retrieve your API Secret from the dashboard
+API_SECRET = '' # Retrieve your API Secret from the dashboard
 
 create_token = CreatePublishToken('my_token')
 create_token.streams.append(CreateUpdatePublishTokenStream('feed1', False))
 
 loop = asyncio.get_event_loop()
-task = publish_token.create(api_secret, create_token)
+
+task = publish_token.create(API_SECRET, create_token)
 token = loop.run_until_complete(task)
 
 print(token)
@@ -131,60 +144,153 @@ print(token)
 ### Create a subscribe token
 
 ```python
-const dolbyio = require('@dolbyio/dolbyio-rest-apis-client');
+import asyncio
+from dolbyio_rest_apis.streaming import subscribe_token
+from dolbyio_rest_apis.streaming.models.subscribe_token import CreateSubscribeToken, CreateUpdateSubscribeTokenStream
 
-const subscribeToken = await dolbyio.streaming.subscribeToken.create('api_secret', {
-    label: 'My token',
-    streams: [
-        {
-            streamName: 'feedA',
-        },
-    ],
-});
-console.log(subscribeToken);
+API_SECRET = '' # Retrieve your API Secret from the dashboard
+
+create_token = CreateSubscribeToken('my_token')
+create_token.streams.append(CreateUpdateSubscribeTokenStream('feed1', False))
+
+loop = asyncio.get_event_loop()
+
+task = publish_token.create(API_SECRET, create_token)
+token = loop.run_until_complete(task)
+
+print(token)
 ```
 
 ## Media Examples
 
-### Media Input and Output
+Here is an example on how to upload a file to the Dolby.io temporary cloud storage, enhance that file and download the result.
 
-Upload a media file to the temporary Dolby.io cloud storage for processing:
+### Get an API token
+
+Get the App Key and Secret from the Dolby.io dashboard and use the following code in your python script.
 
 ```python
 import asyncio
-from dolbyio_rest_apis.media import io
+from dolbyio_rest_apis import authentication
 
-ACCESS_TOKEN = "YOUR_API_TOKEN"
+APP_KEY = 'YOUR_APP_KEY'
+APP_SECRET = 'YOUR_APP_SECRET'
+
+loop = asyncio.get_event_loop()
+
+task = authentication.get_api_token(APP_KEY, APP_SECRET, 2 * 60 * 60) # 2 hours
+at = loop.run_until_complete(task)
+print(f'API token: {at.access_token}')
+```
+
+### Upload a file for processing
+
+Add the following `import` to your script.
+
+```python
+from dolbyio_rest_apis.media import io
+```
+
+Using the API token, start by requesting an upload URL.
+
+```python
+# Temporary storage URL that will be used as reference for the job processing
+input_url = 'dlb://in/file.mp4'
 
 # Get an Upload URL
 task = io.get_upload_url(
-    access_token=ACCESS_TOKEN,
-    dlb_url='dlb://in/file.mp4'
+    access_token=at.access_token,
+    dlb_url=input_url,
 )
 upload_url = loop.run_until_complete(task)
+print(f'Upload URL: {upload_url}')
+```
 
-print(f"Upload URL: {upload_url}")
+Upload a media file to the Dolby.io temporary cloud storage for processing:
+
+```python
+# Location of the original file on the local machine
+IN_FILE_PATH = '/path/to/original_file.mp4'
 
 # Upload the file
 task = io.upload_file(
     upload_url=upload_url,
-    file_path='/path/to/file.mp4'
+    file_path=IN_FILE_PATH,
 )
 loop.run_until_complete(task)
 ```
 
-Download a file that was processed by the API:
+### Start an enhance job
+
+Add the following `import` to your script.
 
 ```python
-import asyncio
-from dolbyio_rest_apis.media import io
+import json
+from dolbyio_rest_apis.media import enhance
+```
 
-ACCESS_TOKEN = "YOUR_API_TOKEN"
+Generate a job description and send it to Dolby.io.
+
+```python
+# Temporary storage URL where the service will write the result file to
+output_url = 'dlb://out/file.mp4'
+
+# Job description
+job = {
+    'input': input_url,
+    'output': output_url,
+    'content': {
+        'type': 'podcast',
+    },
+}
+job_str = json.dumps(job, indent=4)
+print(job_str)
+
+# Start the enhance job and get a job ID back
+task = enhance.start(at.access_token, job_str)
+job_id = loop.run_until_complete(task)
+print(f'Job ID: {job_id}')
+```
+
+### Wait for the job to complete
+
+Add the following `import` to your script.
+
+```python
+import sys
+import time
+```
+
+Get the job status and wait until it is completed.
+
+```python
+task = enhance.get_results(at.access_token, job_id)
+result = loop.run_until_complete(task)
+while result.status in ( 'Pending', 'Running' ):
+    print(f'Job status is {result.status}, taking a 5 second break...')
+    time.sleep(5)
+
+    task = enhance.get_results(at.access_token, job_id)
+    result = loop.run_until_complete(task)
+
+if result.status != 'Success':
+    print('There was a problem with processing the file')
+    print(json.dumps(result, indent=4))
+    sys.exit(1)
+```
+
+### Download a processed file
+
+At this stage, the file has been processed and written to the temporary storage so we can download it.
+
+```python
+# Where to download the file on the local machine
+OUT_FILE_PATH = '/path/to/processed_file.mp4'
 
 task = io.download_file(
-    access_token=ACCESS_TOKEN,
-    dlb_url='dlb://out/file.mp4',
-    file_path='/path/to/processed_file.mp4'
+    access_token=at.access_token,
+    dlb_url=output_url,
+    file_path=OUT_FILE_PATH,
 )
 loop.run_until_complete(task)
 ```

--- a/client/README.md
+++ b/client/README.md
@@ -18,7 +18,7 @@ python3 -m pip install --upgrade dolbyio-rest-apis
 
 ## Logging
 
-You can change the log level by using the Python (logging)[https://docs.python.org/3/library/logging.html] library.
+You can change the log level by using the Python [logging](https://docs.python.org/3/library/logging.html) library.
 
 ```python
 import logging

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -2,4 +2,3 @@ aiohttp>=3.7.4
 aiofiles>=0.7.0
 aiohttp-retry>=2.4.6
 certifi>=2022.12.7
-Deprecated

--- a/client/src/dolbyio_rest_apis/authentication.py
+++ b/client/src/dolbyio_rest_apis/authentication.py
@@ -1,13 +1,14 @@
 """
-dolbyio_rest_apis.media.platform
+dolbyio_rest_apis.communications.authentication
 ~~~~~~~~~~~~~~~
 
-This module contains the functions to work with the Platform APIs.
+This module contains the functions to work with the authentication API.
 """
 
 from dolbyio_rest_apis.core.helpers import add_if_not_none
-from dolbyio_rest_apis.media.internal.http_context import MediaHttpContext
-from dolbyio_rest_apis.media.models.access_token import AccessToken
+from dolbyio_rest_apis.core.urls import get_api_url
+from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
+from .models import AccessToken
 
 async def get_api_token(
         app_key: str,
@@ -16,10 +17,9 @@ async def get_api_token(
     ) -> AccessToken:
     r"""
     To make any API call, you must acquire a JWT (JSON Web Token) format API token.
-    Make sure to use this API against https://api.dolby.io/v1.
 
-    Note: Even though the OAuth terminology is used in the following APIs, they are not OAuth compliant.
-
+    See: https://docs.dolby.io/communications-apis/reference/get-api-token
+    
     See: https://docs.dolby.io/media-apis/reference/get-api-token
 
     Args:
@@ -42,11 +42,11 @@ async def get_api_token(
     }
     add_if_not_none(data, 'expires_in', expires_in)
 
-    async with MediaHttpContext() as http_context:
+    async with CommunicationsHttpContext() as http_context:
         json_response = await http_context.requests_post_basic_auth(
             app_key=app_key,
             app_secret=app_secret,
-            url='https://api.dolby.io/v1/auth/token',
+            url=f'{get_api_url()}/auth/token',
             data=data
         )
 

--- a/client/src/dolbyio_rest_apis/authentication.py
+++ b/client/src/dolbyio_rest_apis/authentication.py
@@ -1,5 +1,5 @@
 """
-dolbyio_rest_apis.communications.authentication
+dolbyio_rest_apis.authentication
 ~~~~~~~~~~~~~~~
 
 This module contains the functions to work with the authentication API.

--- a/client/src/dolbyio_rest_apis/communications/authentication.py
+++ b/client/src/dolbyio_rest_apis/communications/authentication.py
@@ -5,18 +5,36 @@ dolbyio_rest_apis.communications.authentication
 This module contains the functions to work with the authentication API.
 """
 
-from dolbyio_rest_apis.core.helpers import add_if_not_none
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
-from dolbyio_rest_apis.communications.internal.urls import get_api_url, get_session_url
-from .models import AccessToken
+from dolbyio_rest_apis.core.helpers import add_if_not_none
+from dolbyio_rest_apis.core.urls import get_comms_session_url
+from dolbyio_rest_apis.models import AccessToken
 
-async def _get_access_token(
-        url: str,
+async def get_client_access_token(
         app_key: str,
         app_secret: str,
         expires_in: int=None,
     ) -> AccessToken:
+    r"""
+    This API returns an access token that your backend can request on behalf of a client to initialize
+    the Dolby.io SDK in a secure way.
 
+    See: https://docs.dolby.io/communications-apis/reference/get-client-access-token
+
+    Args:
+        app_key: Your Dolby.io App Key.
+        app_secret: Your Dolby.io App Secret.
+        expires_in: (Optional) Access token expiration time in seconds.
+            The maximum value is 2,592,000, indicating 30 days.
+            If no value is specified, the default is 3,600, indicating one hour.
+
+    Returns:
+        An :class:`AccessToken` object.
+
+    Raises:
+        HttpRequestError: If a client error one occurred.
+        HTTPError: If one occurred.
+    """
     data = {
         'grant_type': 'client_credentials',
     }
@@ -26,68 +44,8 @@ async def _get_access_token(
         json_response = await http_context.requests_post_basic_auth(
             app_key=app_key,
             app_secret=app_secret,
-            url=url,
+            url=f'{get_comms_session_url()}/oauth2/token',
             data=data
         )
 
     return AccessToken(json_response)
-
-async def get_api_token(
-        app_key: str,
-        app_secret: str,
-        expires_in: int=None,
-    ) -> AccessToken:
-    r"""
-    To make any API call, you must acquire a JWT (JSON Web Token) format API token.
-    Make sure to use this API against https://api.dolby.io/v1.
-
-    Note: Even though the OAuth terminology is used in the following APIs, they are not OAuth compliant.
-
-    See: https://docs.dolby.io/communications-apis/reference/get-api-token
-
-    Args:
-        app_key: Your Dolby.io App Key.
-        app_secret: Your Dolby.io App Secret.
-        expires_in: (Optional) API token expiration time in seconds.
-            The maximum value is 2,592,000, indicating 30 days.
-            If no value is specified, the default is 1800, indicating 30 minutes.
-
-    Returns:
-        An :class:`AccessToken` object.
-
-    Raises:
-        HttpRequestError: If a client error one occurred.
-        HTTPError: If one occurred.
-    """
-
-    return await _get_access_token(f'{get_api_url()}/auth/token', app_key, app_secret, expires_in)
-
-async def get_client_access_token(
-        app_key: str,
-        app_secret: str,
-        expires_in: int=None,
-    ) -> AccessToken:
-    r"""
-    This API returns an access token that your backend can request on behalf of a client to initialize
-    the Dolby.io SDK in a secure way. Make sure to use this API against https://session.voxeet.com.
-
-    Note: Even though the OAuth2 terminology is used in the following APIs, they are not OAuth2 compliant.
-
-    See: https://docs.dolby.io/communications-apis/reference/get-client-access-token
-
-    Args:
-        app_key: Your Dolby.io App Key.
-        app_secret: Your Dolby.io App Secret.
-        expires_in: (Optional) Access token expiration time in seconds.
-            The maximum value is 2,592,000, indicating 30 days. If no value is specified, the default is 600,
-            indicating ten minutes.
-
-    Returns:
-        An :class:`AccessToken` object.
-
-    Raises:
-        HttpRequestError: If a client error one occurred.
-        HTTPError: If one occurred.
-    """
-
-    return await _get_access_token(f'{get_session_url()}/oauth2/token', app_key, app_secret, expires_in)

--- a/client/src/dolbyio_rest_apis/communications/conference.py
+++ b/client/src/dolbyio_rest_apis/communications/conference.py
@@ -6,9 +6,9 @@ This module contains the functions to work with the conference API.
 """
 
 from dataclasses import asdict
-from dolbyio_rest_apis.core.helpers import get_value, add_if_not_none
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
-from dolbyio_rest_apis.communications.internal.urls import get_comms_url_v2
+from dolbyio_rest_apis.core.helpers import get_value, add_if_not_none
+from dolbyio_rest_apis.core.urls import get_comms_url_v2
 from .models import UserToken, Conference, SpatialAudioEnvironment, SpatialAudioListener, SpatialAudioUser, RTCPMode, Participant, VideoCodec
 from typing import List
 
@@ -36,7 +36,8 @@ async def create_conference(
         access_token: Access token to use for authentication.
         owner_external_id: External ID of the conference owner.
         alias: (Optional) Name of the conference.
-        pincode: (Optional)
+        pincode: (Optional) The PIN code of the conference.
+            This applies to conferences using PSTN (telephony network).
         dolby_voice: (Optional) Indicates if Dolby Voice is enabled for the conference.
             The `True` value creates the conference with Dolby Voice enabled.
         live_recording: (Optional) Indicates if live recording is enabled for the conference.

--- a/client/src/dolbyio_rest_apis/communications/models.py
+++ b/client/src/dolbyio_rest_apis/communications/models.py
@@ -13,7 +13,7 @@ from dolbyio_rest_apis.core.helpers import get_value_or_default, in_and_not_none
 class Participant:
     """The :class:`Participant` object, which represents a participant's permissions."""
 
-    def __init__(self, external_id, permissions, notify):
+    def __init__(self, external_id: str, permissions, notify: bool):
         self.external_id = external_id
         self.permissions = permissions
         self.notify = notify

--- a/client/src/dolbyio_rest_apis/communications/models.py
+++ b/client/src/dolbyio_rest_apis/communications/models.py
@@ -5,21 +5,10 @@ dolbyio_rest_apis.communications.models
 This module contains the models used by the Dolby.io APIs.
 """
 
-from dolbyio_rest_apis.core.helpers import get_value_or_default, in_and_not_none
 from enum import Enum
 from dataclasses import dataclass
 from typing import List
-
-class AccessToken(dict):
-    """The :class:`AccessToken` object, which represents the access token."""
-
-    def __init__(self, dictionary: dict):
-        dict.__init__(self, dictionary)
-
-        self.token_type = get_value_or_default(self, 'token_type', None)
-        self.access_token = get_value_or_default(self, 'access_token', None)
-        self.refresh_token = get_value_or_default(self, 'refresh_token', None)
-        self.expires_in_val = get_value_or_default(self, 'expires_in', 0)
+from dolbyio_rest_apis.core.helpers import get_value_or_default, in_and_not_none
 
 class Participant:
     """The :class:`Participant` object, which represents a participant's permissions."""

--- a/client/src/dolbyio_rest_apis/communications/monitor/conferences.py
+++ b/client/src/dolbyio_rest_apis/communications/monitor/conferences.py
@@ -6,8 +6,8 @@ This module contains the functions to work with the monitor API related to confe
 """
 
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
-from dolbyio_rest_apis.communications.internal.urls import get_monitor_url
 from dolbyio_rest_apis.communications.monitor.models import GetConferencesResponse, ConferenceSummary, ConferenceStatistics, ConferenceParticipants, ConferenceParticipant
+from dolbyio_rest_apis.core.urls import get_comms_monitor_url
 from typing import Any, Dict, List
 
 async def get_conferences(
@@ -59,7 +59,7 @@ async def get_conferences(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_monitor_url()}/conferences'
+    url = f'{get_comms_monitor_url()}/conferences'
 
     params = {
         'from': tr_from,
@@ -129,7 +129,7 @@ async def get_all_conferences(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_monitor_url()}/conferences'
+    url = f'{get_comms_monitor_url()}/conferences'
 
     params = {
         'from': tr_from,
@@ -187,7 +187,7 @@ async def get_conference(
         HTTPError: If one occurred.
     """
 
-    url = f'{get_monitor_url()}/conferences/{conference_id}'
+    url = f'{get_comms_monitor_url()}/conferences/{conference_id}'
 
     params = {
         'livestats': str(live_stats),
@@ -230,7 +230,7 @@ async def get_conference_statistics(
         HTTPError: If one occurred.
     """
 
-    url = f'{get_monitor_url()}/conferences/{conference_id}/statistics'
+    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/statistics'
 
     async with CommunicationsHttpContext() as http_context:
         json_response = await http_context.requests_get(
@@ -280,7 +280,7 @@ async def get_conference_participants(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_monitor_url()}/conferences/{conference_id}/participants'
+    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/participants'
 
     params = {
         'from': tr_from,
@@ -336,7 +336,7 @@ async def get_all_conference_participants(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_monitor_url()}/conferences/{conference_id}/participants'
+    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/participants'
 
     params = {
         'from': tr_from,
@@ -415,7 +415,7 @@ async def get_conference_participant(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_monitor_url()}/conferences/{conference_id}/participants/{participant_id}'
+    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/participants/{participant_id}'
 
     params = {
         'from': tr_from,

--- a/client/src/dolbyio_rest_apis/communications/monitor/recordings.py
+++ b/client/src/dolbyio_rest_apis/communications/monitor/recordings.py
@@ -5,10 +5,9 @@ dolbyio_rest_apis.communications.monitor.recordings
 This module contains the functions to work with the monitor API related to recordings.
 """
 
-from deprecated import deprecated
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
-from dolbyio_rest_apis.communications.internal.urls import get_monitor_url
 from dolbyio_rest_apis.communications.monitor.models import GetRecordingsResponse, Recording, DolbyVoiceRecording
+from dolbyio_rest_apis.core.urls import get_comms_monitor_url
 from typing import Any, List
 
 async def get_recordings(
@@ -46,7 +45,7 @@ async def get_recordings(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_monitor_url()}/recordings'
+    url = f'{get_comms_monitor_url()}/recordings'
 
     params = {
         'from': tr_from,
@@ -97,7 +96,7 @@ async def get_all_recordings(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_monitor_url()}/recordings'
+    url = f'{get_comms_monitor_url()}/recordings'
 
     params = {
         'from': tr_from,
@@ -156,7 +155,7 @@ async def get_recording(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_monitor_url()}/conferences/{conference_id}/recordings'
+    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/recordings'
 
     params = {
         'from': tr_from,
@@ -205,7 +204,7 @@ async def delete_recording(
         HTTPError: If one occurred.
     """
 
-    url = f'{get_monitor_url()}/conferences/{conference_id}/recordings'
+    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/recordings'
 
     async with CommunicationsHttpContext() as http_context:
         await http_context.requests_delete(
@@ -237,7 +236,7 @@ async def get_dolby_voice_recordings(
         HTTPError: If one occurred.
     """
 
-    url = f'{get_monitor_url()}/conferences/{conference_id}/recordings/audio'
+    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/recordings/audio'
 
     async with CommunicationsHttpContext() as http_context:
         json_response = await http_context.requests_get(
@@ -246,71 +245,3 @@ async def get_dolby_voice_recordings(
         )
 
     return DolbyVoiceRecording(json_response)
-
-@deprecated(reason='This API is no longer applicable on the Dolby.io Communications APIs platform.')
-async def download_mp4_recording(
-        access_token: str,
-        conference_id: str,
-        file_path: str,
-    ) -> None:
-    r"""
-    Download the conference recording in MP4 format
-
-    Download the conference recording in the MP4 video format.
-    For more information, see the [Recording](https://docs.dolby.io/communications-apis/docs/guides-recording-mechanisms) document.
-
-    See: https://docs.dolby.io/communications-apis/reference/get-mp4-recording
-
-    Args:
-        access_token: Access token to use for authentication.
-        conference_id: Identifier of the conference.
-        file_path: Where to save the file.
-
-    Raises:
-        HttpRequestError: If a client error one occurred.
-        HTTPError: If one occurred.
-    """
-
-    url = f'{get_monitor_url()}/conferences/{conference_id}/recordings/mp4'
-
-    async with CommunicationsHttpContext() as http_context:
-        await http_context.download(
-            access_token=access_token,
-            url=url,
-            accept='video/mp4',
-            file_path=file_path,
-        )
-
-@deprecated(reason='This API is no longer applicable on the Dolby.io Communications APIs platform.')
-async def download_mp3_recording(
-        access_token: str,
-        conference_id: str,
-        file_path: str,
-    ) -> None:
-    r"""
-    Download the conference recording in MP3 format
-
-    Download the conference recording in the MP3 audio format. This API is available only for non-Dolby Voice conferences.
-    For more information, see the [Recording](https://docs.dolby.io/communications-apis/docs/guides-recording-mechanisms) document.
-
-    See: https://docs.dolby.io/communications-apis/reference/get-mp3-recording
-
-    Args:
-        access_token: Access token to use for authentication.
-        conference_id: Identifier of the conference.
-        file_path: Where to save the file.
-
-    Raises:
-        HttpRequestError: If a client error one occurred.
-        HTTPError: If one occurred.
-    """
-
-    url = f'{get_monitor_url()}/conferences/{conference_id}/recordings/mp3'
-
-    async with CommunicationsHttpContext() as http_context:
-        await http_context.download(
-            access_token=access_token,
-            url=url,
-            accept='video/mpeg',
-            file_path=file_path,
-        )

--- a/client/src/dolbyio_rest_apis/communications/monitor/webhooks.py
+++ b/client/src/dolbyio_rest_apis/communications/monitor/webhooks.py
@@ -6,8 +6,8 @@ This module contains the functions to work with the monitor API related to webho
 """
 
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
-from dolbyio_rest_apis.communications.internal.urls import get_monitor_url
 from dolbyio_rest_apis.communications.monitor.models import GetWebHookResponse, WebHook
+from dolbyio_rest_apis.core.urls import get_comms_monitor_url
 from typing import Any, List
 
 async def get_events(
@@ -45,7 +45,7 @@ async def get_events(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_monitor_url()}/'
+    url = f'{get_comms_monitor_url()}/'
     if not conference_id is None:
         url += f'conferences/{conference_id}/'
     url += 'webhooks'
@@ -100,7 +100,7 @@ async def get_all_events(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_monitor_url()}/'
+    url = f'{get_comms_monitor_url()}/'
     if not conference_id is None:
         url += f'conferences/{conference_id}/'
     url += 'webhooks'

--- a/client/src/dolbyio_rest_apis/communications/recording.py
+++ b/client/src/dolbyio_rest_apis/communications/recording.py
@@ -6,8 +6,8 @@ This module contains the functions to work with the recording API.
 """
 
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
-from dolbyio_rest_apis.communications.internal.urls import get_comms_url_v2
 from dolbyio_rest_apis.core.helpers import add_if_not_none
+from dolbyio_rest_apis.core.urls import get_comms_url_v2
 
 async def start(
         access_token: str,

--- a/client/src/dolbyio_rest_apis/communications/remix.py
+++ b/client/src/dolbyio_rest_apis/communications/remix.py
@@ -6,8 +6,8 @@ This module contains the functions to work with the remix API.
 """
 
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
-from dolbyio_rest_apis.communications.internal.urls import get_comms_url_v2
 from dolbyio_rest_apis.core.helpers import add_if_not_none
+from dolbyio_rest_apis.core.urls import get_comms_url_v2
 from .models import RemixStatus
 
 async def start(

--- a/client/src/dolbyio_rest_apis/communications/streaming.py
+++ b/client/src/dolbyio_rest_apis/communications/streaming.py
@@ -6,8 +6,8 @@ This module contains the functions to work with the streaming API.
 """
 
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
-from dolbyio_rest_apis.communications.internal.urls import get_comms_url_v2
 from dolbyio_rest_apis.core.helpers import add_if_not_none
+from dolbyio_rest_apis.core.urls import get_comms_url_v2
 
 async def start_rtmp(
         access_token: str,

--- a/client/src/dolbyio_rest_apis/core/urls.py
+++ b/client/src/dolbyio_rest_apis/core/urls.py
@@ -1,18 +1,23 @@
 """
-dolbyio_rest_apis.communications.internal.urls
+dolbyio_rest_apis.core.urls
 ~~~~~~~~~~~~~~~
 
 This module contains the URLs to use to call the REST APIs.
 """
 
 API_URL = 'api.dolby.io'
+
 COMMS_URL = 'comms.api.dolby.io'
-SESSION_URL = 'session.voxeet.com/v1'
+COMMS_SESSION_URL = 'session.voxeet.com/v1'
+
+SAPI_URL = 'api.millicast.com'
+
+MAPI_URL = 'api.dolby.com'
 
 def get_api_url() -> str:
     return f'https://{API_URL}/v1'
 
-def get_monitor_url() -> str:
+def get_comms_monitor_url() -> str:
     return f'https://{COMMS_URL}/v1/monitor'
 
 def get_comms_url_v2(region: str = None) -> str:
@@ -20,5 +25,11 @@ def get_comms_url_v2(region: str = None) -> str:
         return f'https://{COMMS_URL}/v2'
     return f'https://{region}.{COMMS_URL}/v2'
 
-def get_session_url() -> str:
-    return f'https://{SESSION_URL}'
+def get_comms_session_url() -> str:
+    return f'https://{COMMS_SESSION_URL}'
+
+def get_rts_url() -> str:
+    return f'https://{SAPI_URL}'
+
+def get_mapi_url() -> str:
+    return f'https://{MAPI_URL}'

--- a/client/src/dolbyio_rest_apis/media/analyze.py
+++ b/client/src/dolbyio_rest_apis/media/analyze.py
@@ -5,6 +5,7 @@ dolbyio_rest_apis.media.analyze
 This module contains the functions to work with the Analyze APIs.
 """
 
+from dolbyio_rest_apis.core.urls import get_mapi_url
 from dolbyio_rest_apis.media.internal.http_context import MediaHttpContext
 from dolbyio_rest_apis.media.models.analyze_response import AnalyzeJobResponse
 
@@ -55,7 +56,7 @@ async def start(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_post(
             access_token=access_token,
-            url='https://api.dolby.com/media/analyze',
+            url=f'{get_mapi_url()}/media/analyze',
             payload=job_content,
         )
 
@@ -91,7 +92,7 @@ async def get_results(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_get(
             access_token=access_token,
-            url='https://api.dolby.com/media/analyze',
+            url=f'{get_mapi_url()}/media/analyze',
             params=params
         )
 

--- a/client/src/dolbyio_rest_apis/media/analyze_speech.py
+++ b/client/src/dolbyio_rest_apis/media/analyze_speech.py
@@ -5,6 +5,7 @@ dolbyio_rest_apis.media.analyze_speech
 This module contains the functions to work with the Speech Analytics APIs.
 """
 
+from dolbyio_rest_apis.core.urls import get_mapi_url
 from dolbyio_rest_apis.media.internal.http_context import MediaHttpContext
 from dolbyio_rest_apis.media.models.analyze_speech_response import AnalyzeSpeechJob
 
@@ -17,7 +18,7 @@ async def start(
 
     The `input` location of your source media file and `output` location of your Analyze JSON results file are required.
 
-    This is an asynchronous operation so you will receive a `job_id` to be used to get the job status and result.
+    This is an asynchronous operation so you will receive a job identifier to be used to get the job status and result.
 
     See: https://docs.dolby.io/media-apis/reference/media-analyze-speech-post
 
@@ -46,7 +47,7 @@ async def start(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_post(
             access_token=access_token,
-            url='https://api.dolby.com/media/analyze/speech',
+            url=f'{get_mapi_url()}/media/analyze/speech',
             payload=job_content,
         )
 
@@ -82,7 +83,7 @@ async def get_results(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_get(
             access_token=access_token,
-            url='https://api.dolby.com/media/analyze/speech',
+            url=f'{get_mapi_url()}/media/analyze/speech',
             params=params
         )
 

--- a/client/src/dolbyio_rest_apis/media/diagnose.py
+++ b/client/src/dolbyio_rest_apis/media/diagnose.py
@@ -5,6 +5,7 @@ dolbyio_rest_apis.media.diagnose
 This module contains the functions to work with the Diagnose APIs.
 """
 
+from dolbyio_rest_apis.core.urls import get_mapi_url
 from dolbyio_rest_apis.media.internal.http_context import MediaHttpContext
 from dolbyio_rest_apis.media.models.diagnose_response import DiagnoseJob
 
@@ -44,7 +45,7 @@ async def start(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_post(
             access_token=access_token,
-            url='https://api.dolby.com/media/diagnose',
+            url=f'{get_mapi_url()}/media/diagnose',
             payload=job_content,
         )
 
@@ -87,7 +88,7 @@ async def get_results(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_get(
             access_token=access_token,
-            url='https://api.dolby.com/media/diagnose',
+            url=f'{get_mapi_url()}/media/diagnose',
             params=params
         )
 

--- a/client/src/dolbyio_rest_apis/media/enhance.py
+++ b/client/src/dolbyio_rest_apis/media/enhance.py
@@ -5,6 +5,7 @@ dolbyio_rest_apis.media.enhance
 This module contains the functions to work with the Enhance APIs.
 """
 
+from dolbyio_rest_apis.core.urls import get_mapi_url
 from dolbyio_rest_apis.media.internal.http_context import MediaHttpContext
 from dolbyio_rest_apis.media.models.enhance_response import EnhanceJob
 
@@ -39,7 +40,7 @@ async def start(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_post(
             access_token=access_token,
-            url='https://api.dolby.com/media/enhance',
+            url=f'{get_mapi_url()}/media/enhance',
             payload=job_content,
         )
 
@@ -77,7 +78,7 @@ async def get_results(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_get(
             access_token=access_token,
-            url='https://api.dolby.com/media/enhance',
+            url=f'{get_mapi_url()}/media/enhance',
             params=params
         )
 

--- a/client/src/dolbyio_rest_apis/media/io.py
+++ b/client/src/dolbyio_rest_apis/media/io.py
@@ -5,6 +5,7 @@ dolbyio_rest_apis.media.io
 This module contains the functions to work with the IO APIs.
 """
 
+from dolbyio_rest_apis.core.urls import get_mapi_url
 from dolbyio_rest_apis.media.internal.http_context import MediaHttpContext
 
 async def get_upload_url(
@@ -41,7 +42,7 @@ async def get_upload_url(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_post(
             access_token=access_token,
-            url='https://api.dolby.com/media/input',
+            url=f'{get_mapi_url()}/media/input',
             payload=payload
         )
 
@@ -98,7 +99,7 @@ async def download_file(
     async with MediaHttpContext() as http_context:
         await http_context.download(
             access_token=access_token,
-            url='https://api.dolby.com/media/output',
+            url=f'{get_mapi_url()}/media/output',
             file_path=file_path,
             params=params,
         )

--- a/client/src/dolbyio_rest_apis/media/jobs.py
+++ b/client/src/dolbyio_rest_apis/media/jobs.py
@@ -5,10 +5,11 @@ dolbyio_rest_apis.media.jobs
 This module contains the functions to work with the Jobs APIs.
 """
 
+from typing import List
 from dolbyio_rest_apis.core.helpers import add_if_not_none
+from dolbyio_rest_apis.core.urls import get_mapi_url
 from dolbyio_rest_apis.media.internal.http_context import MediaHttpContext
 from dolbyio_rest_apis.media.models.jobs_response import JobsResponse, Job
-from typing import List
 
 async def _list_jobs(
         http_context: MediaHttpContext,
@@ -26,7 +27,7 @@ async def _list_jobs(
 
     json_response = await http_context.requests_get(
         access_token=access_token,
-        url='https://api.dolby.com/media/jobs',
+        url=f'{get_mapi_url()}/media/jobs',
         params=params
     )
 
@@ -147,6 +148,6 @@ async def cancel(
     async with MediaHttpContext() as http_context:
         await http_context.requests_post(
             access_token=access_token,
-            url='https://api.dolby.com/media/jobs/cancel',
+            url=f'{get_mapi_url()}/media/jobs/cancel',
             params=params,
         )

--- a/client/src/dolbyio_rest_apis/media/mastering.py
+++ b/client/src/dolbyio_rest_apis/media/mastering.py
@@ -5,6 +5,7 @@ dolbyio_rest_apis.media.transcode
 This module contains the functions to work with the Transcode APIs.
 """
 
+from dolbyio_rest_apis.core.urls import get_mapi_url
 from dolbyio_rest_apis.media.internal.http_context import MediaHttpContext
 from dolbyio_rest_apis.media.models.mastering_response import MasteringPreviewJob, MasteringJob
 
@@ -44,7 +45,7 @@ async def start_preview(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_post(
             access_token=access_token,
-            url='https://api.dolby.com/media/master/preview',
+            url=f'{get_mapi_url()}/media/master/preview',
             payload=job_content,
         )
 
@@ -81,7 +82,7 @@ async def get_preview_results(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_get(
             access_token=access_token,
-            url='https://api.dolby.com/media/master/preview',
+            url=f'{get_mapi_url()}/media/master/preview',
             params=params
         )
 
@@ -121,7 +122,7 @@ async def start(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_post(
             access_token=access_token,
-            url='https://api.dolby.com/media/master',
+            url=f'{get_mapi_url()}/media/master',
             payload=job_content,
         )
 
@@ -158,7 +159,7 @@ async def get_results(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_get(
             access_token=access_token,
-            url='https://api.dolby.com/media/master',
+            url=f'{get_mapi_url()}/media/master',
             params=params
         )
 

--- a/client/src/dolbyio_rest_apis/media/transcode.py
+++ b/client/src/dolbyio_rest_apis/media/transcode.py
@@ -5,6 +5,7 @@ dolbyio_rest_apis.media.transcode
 This module contains the functions to work with the Transcode APIs.
 """
 
+from dolbyio_rest_apis.core.urls import get_mapi_url
 from dolbyio_rest_apis.media.internal.http_context import MediaHttpContext
 from dolbyio_rest_apis.media.models.transcode_response import TranscodeJob
 
@@ -41,7 +42,7 @@ async def start(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_post(
             access_token=access_token,
-            url='https://api.dolby.com/media/transcode',
+            url=f'{get_mapi_url()}/media/transcode',
             payload=job_content,
         )
 
@@ -77,7 +78,7 @@ async def get_results(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_get(
             access_token=access_token,
-            url='https://api.dolby.com/media/transcode',
+            url=f'{get_mapi_url()}/media/transcode',
             params=params
         )
 

--- a/client/src/dolbyio_rest_apis/media/webhooks.py
+++ b/client/src/dolbyio_rest_apis/media/webhooks.py
@@ -6,6 +6,7 @@ This module contains the functions to work with the Platform Webhooks APIs.
 """
 
 from dolbyio_rest_apis.core.helpers import add_if_not_none
+from dolbyio_rest_apis.core.urls import get_mapi_url
 from dolbyio_rest_apis.media.internal.http_context import MediaHttpContext
 from dolbyio_rest_apis.media.models.webhook import Webhook
 from typing import Any, Dict
@@ -32,8 +33,6 @@ async def register_webhook(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    request_url = 'https://api.dolby.com/media/webhooks'
-
     payload = {
         'callback': {
             'url': url,
@@ -44,7 +43,7 @@ async def register_webhook(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_post(
             access_token=access_token,
-            url=request_url,
+            url=f'{get_mapi_url()}/media/webhooks',
             payload=payload,
         )
 
@@ -73,8 +72,6 @@ async def update_webhook(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    request_url = 'https://api.dolby.com/media/webhooks'
-
     params = {
         'id': webhook_id
     }
@@ -89,7 +86,7 @@ async def update_webhook(
     async with MediaHttpContext() as http_context:
         await http_context.requests_put(
             access_token=access_token,
-            url=request_url,
+            url=f'{get_mapi_url()}/media/webhooks',
             params=params,
             payload=payload,
         )
@@ -122,7 +119,7 @@ async def retrieve_webhook(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_get(
             access_token=access_token,
-            url='https://api.dolby.com/media/webhooks',
+            url=f'{get_mapi_url()}/media/webhooks',
             params=params,
         )
 
@@ -156,7 +153,7 @@ async def delete_webhook(
     async with MediaHttpContext() as http_context:
         json_response = await http_context.requests_delete(
             access_token=access_token,
-            url='https://api.dolby.com/media/webhooks',
+            url=f'{get_mapi_url()}/media/webhooks',
             params=params,
         )
 

--- a/client/src/dolbyio_rest_apis/models.py
+++ b/client/src/dolbyio_rest_apis/models.py
@@ -1,8 +1,8 @@
 """
-dolbyio_rest_apis.media.models.access_token
+dolbyio_rest_apis.communications.models
 ~~~~~~~~~~~~~~~
 
-This module contains the models used by the Access Token model.
+This module contains the models used by the Dolby.io APIs.
 """
 
 from dolbyio_rest_apis.core.helpers import get_value_or_default
@@ -15,5 +15,5 @@ class AccessToken(dict):
 
         self.token_type = get_value_or_default(self, 'token_type', None)
         self.access_token = get_value_or_default(self, 'access_token', None)
+        self.refresh_token = get_value_or_default(self, 'refresh_token', None)
         self.expires_in_val = get_value_or_default(self, 'expires_in', 0)
-        self.status = get_value_or_default(self, 'status', None)

--- a/client/src/dolbyio_rest_apis/streaming/cluster.py
+++ b/client/src/dolbyio_rest_apis/streaming/cluster.py
@@ -5,8 +5,8 @@ dolbyio_rest_apis.streaming.cluster
 This module contains the functions to work with the Cluster APIs.
 """
 
+from dolbyio_rest_apis.core.urls import get_rts_url
 from dolbyio_rest_apis.streaming.internal.http_context import StreamingHttpContext
-from dolbyio_rest_apis.streaming.internal.urls import SAPI_URL
 from dolbyio_rest_apis.streaming.models.cluster import ClusterResponse
 
 async def read(
@@ -15,7 +15,7 @@ async def read(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_get(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/cluster',
+            url=f'{get_rts_url()}/api/cluster',
         )
 
     return ClusterResponse(json_response)
@@ -31,7 +31,7 @@ async def update(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_put(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/cluster',
+            url=f'{get_rts_url()}/api/cluster',
             payload=payload,
         )
 

--- a/client/src/dolbyio_rest_apis/streaming/internal/urls.py
+++ b/client/src/dolbyio_rest_apis/streaming/internal/urls.py
@@ -1,8 +1,0 @@
-"""
-dolbyio_rest_apis.streaming.internal.urls
-~~~~~~~~~~~~~~~
-
-This module contains the URLs to use to call the REST APIs.
-"""
-
-SAPI_URL = 'https://api.millicast.com'

--- a/client/src/dolbyio_rest_apis/streaming/publish_token.py
+++ b/client/src/dolbyio_rest_apis/streaming/publish_token.py
@@ -7,8 +7,8 @@ This module contains the functions to work with the Publish Token APIs.
 
 from typing import List
 from dolbyio_rest_apis.core.helpers import add_if_not_none
+from dolbyio_rest_apis.core.urls import get_rts_url
 from dolbyio_rest_apis.streaming.internal.http_context import StreamingHttpContext
-from dolbyio_rest_apis.streaming.internal.urls import SAPI_URL
 from dolbyio_rest_apis.streaming.models.publish_token import PublishToken, UpdatePublishToken, CreatePublishToken, ActivePublishToken, DisablePublishTokenResponse
 
 async def read(
@@ -18,7 +18,7 @@ async def read(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_get(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/publish_token/{token_id}',
+            url=f'{get_rts_url()}/api/publish_token/{token_id}',
         )
 
     return PublishToken(json_response)
@@ -30,7 +30,7 @@ async def delete(
     async with StreamingHttpContext() as http_context:
         await http_context.requests_delete(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/publish_token/{token_id}',
+            url=f'{get_rts_url()}/api/publish_token/{token_id}',
         )
 
 async def update(
@@ -71,7 +71,7 @@ async def update(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_put(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/publish_token/{token_id}',
+            url=f'{get_rts_url()}/api/publish_token/{token_id}',
             payload=payload,
         )
 
@@ -94,7 +94,7 @@ async def list_tokens(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_get(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/publish_token/list',
+            url=f'{get_rts_url()}/api/publish_token/list',
             params=params,
         )
 
@@ -131,7 +131,7 @@ async def create(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_post(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/publish_token',
+            url=f'{get_rts_url()}/api/publish_token',
             payload=payload,
         )
 
@@ -148,7 +148,7 @@ async def get_active_publish_token_id(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_get(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/publish_token/active',
+            url=f'{get_rts_url()}/api/publish_token/active',
             params=params,
         )
 
@@ -160,7 +160,7 @@ async def get_all_active_publish_token_id(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_get(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/publish_token/active/all',
+            url=f'{get_rts_url()}/api/publish_token/active/all',
         )
 
     return ActivePublishToken(json_response)
@@ -175,7 +175,7 @@ async def disable(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_patch(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/publish_token/disable',
+            url=f'{get_rts_url()}/api/publish_token/disable',
             payload=payload,
         )
 

--- a/client/src/dolbyio_rest_apis/streaming/stream.py
+++ b/client/src/dolbyio_rest_apis/streaming/stream.py
@@ -5,8 +5,8 @@ dolbyio_rest_apis.streaming.stream
 This module contains the functions to work with the Stream APIs.
 """
 
+from dolbyio_rest_apis.core.urls import get_rts_url
 from dolbyio_rest_apis.streaming.internal.http_context import StreamingHttpContext
-from dolbyio_rest_apis.streaming.internal.urls import SAPI_URL
 
 async def stop(
         api_secret: str,
@@ -20,7 +20,7 @@ async def stop(
     async with StreamingHttpContext() as http_context:
         await http_context.requests_post(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/stream/stop',
+            url=f'{get_rts_url()}/api/stream/stop',
             payload=payload,
         )
 
@@ -30,5 +30,5 @@ async def stop_all(
     async with StreamingHttpContext() as http_context:
         await http_context.requests_post(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/stream/stop/all',
+            url=f'{get_rts_url()}/api/stream/stop/all',
         )

--- a/client/src/dolbyio_rest_apis/streaming/subscribe_token.py
+++ b/client/src/dolbyio_rest_apis/streaming/subscribe_token.py
@@ -7,8 +7,8 @@ This module contains the functions to work with the Subscribe Token APIs.
 
 from typing import List
 from dolbyio_rest_apis.core.helpers import add_if_not_none
+from dolbyio_rest_apis.core.urls import get_rts_url
 from dolbyio_rest_apis.streaming.internal.http_context import StreamingHttpContext
-from dolbyio_rest_apis.streaming.internal.urls import SAPI_URL
 from dolbyio_rest_apis.streaming.models.subscribe_token import SubscribeToken, UpdateSubscribeToken, CreateSubscribeToken
 
 async def read(
@@ -18,7 +18,7 @@ async def read(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_get(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/subscribe_token/{token_id}',
+            url=f'{get_rts_url()}/api/subscribe_token/{token_id}',
         )
 
     return SubscribeToken(json_response)
@@ -30,7 +30,7 @@ async def delete(
     async with StreamingHttpContext() as http_context:
         await http_context.requests_delete(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/subscribe_token/{token_id}',
+            url=f'{get_rts_url()}/api/subscribe_token/{token_id}',
         )
 
 async def update(
@@ -67,7 +67,7 @@ async def update(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_put(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/subscribe_token/{token_id}',
+            url=f'{get_rts_url()}/api/subscribe_token/{token_id}',
             payload=payload,
         )
 
@@ -90,7 +90,7 @@ async def list_tokens(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_get(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/subscribe_token/list',
+            url=f'{get_rts_url()}/api/subscribe_token/list',
             params=params,
         )
 
@@ -124,7 +124,7 @@ async def create(
     async with StreamingHttpContext() as http_context:
         json_response = await http_context.requests_post(
             api_secret=api_secret,
-            url=f'{SAPI_URL}/api/subscribe_token',
+            url=f'{get_rts_url()}/api/subscribe_token',
             payload=token,
         )
 


### PR DESCRIPTION
* Update the readme with better code examples
* Remove deprecated functions `download_mp4_recording` and `download_mp3_recording` from `dolbyio_rest_apis.communications.monitor.recordings`.
* Remove the `dolbyio_rest_apis.media.platform` module.
* Getting an API Token for Media and Communications APIs is now done with the module `dolbyio_rest_apis.authentication`