### PR TITLE
Authentication token max duration is 24 hours

### DIFF
--- a/client/src/dolbyio_rest_apis/authentication.py
+++ b/client/src/dolbyio_rest_apis/authentication.py
@@ -26,7 +26,7 @@ async def get_api_token(
         app_key: Your Dolby.io App Key.
         app_secret: Your Dolby.io App Secret.
         expires_in: (Optional) API token expiration time in seconds.
-            The maximum value is 2,592,000, indicating 30 days.
+            The maximum value is 86,400, indicating 24 hours.
             If no value is specified, the default is 1800, indicating 30 minutes.
 
     Returns:

--- a/client/src/dolbyio_rest_apis/communications/authentication.py
+++ b/client/src/dolbyio_rest_apis/communications/authentication.py
@@ -25,7 +25,7 @@ async def get_client_access_token(
         app_key: Your Dolby.io App Key.
         app_secret: Your Dolby.io App Secret.
         expires_in: (Optional) Access token expiration time in seconds.
-            The maximum value is 2,592,000, indicating 30 days.
+            The maximum value is 86,400, indicating 24 hours.
             If no value is specified, the default is 3,600, indicating one hour.
 
     Returns:


### PR DESCRIPTION
The maximum duration for an API Token and Session Access Token is now 24 hours.