### PR TITLE
Version 4.0.0

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -2,4 +2,3 @@ aiohttp>=3.7.4
 aiofiles>=0.7.0
 aiohttp-retry>=2.4.6
 certifi>=2022.12.7
-Deprecated>=1.2.14

--- a/client/src/dolbyio_rest_apis/communications/authentication.py
+++ b/client/src/dolbyio_rest_apis/communications/authentication.py
@@ -5,56 +5,11 @@ dolbyio_rest_apis.communications.authentication
 This module contains the functions to work with the authentication API.
 """
 
-from deprecated import deprecated
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
 from dolbyio_rest_apis.core.helpers import add_if_not_none
-from dolbyio_rest_apis.core.urls import get_comms_session_url, get_comms_url_v2
+from dolbyio_rest_apis.core.urls import get_comms_url_v2
 from dolbyio_rest_apis.models import AccessToken
 from typing import List
-
-@deprecated(reason='''
-    This function is now deprecated and will be removed in the next release of this SDK.
-    Please start using :meth:`get_client_access_token_v2` instead.
-    ''')
-async def get_client_access_token(
-        app_key: str,
-        app_secret: str,
-        expires_in: int=None,
-    ) -> AccessToken:
-    r"""
-    This API returns an access token that your backend can request on behalf of a client to initialize
-    the Dolby.io SDK in a secure way.
-
-    See: https://docs.dolby.io/communications-apis/reference/get-client-access-token-v1
-
-    Args:
-        app_key: Your Dolby.io App Key.
-        app_secret: Your Dolby.io App Secret.
-        expires_in: (Optional) Access token expiration time in seconds.
-            The maximum value is 86,400, indicating 24 hours.
-            If no value is specified, the default is 3,600, indicating one hour.
-
-    Returns:
-        An :class:`AccessToken` object.
-
-    Raises:
-        HttpRequestError: If a client error one occurred.
-        HTTPError: If one occurred.
-    """
-    data = {
-        'grant_type': 'client_credentials',
-    }
-    add_if_not_none(data, 'expires_in', expires_in)
-
-    async with CommunicationsHttpContext() as http_context:
-        json_response = await http_context.requests_post_basic_auth(
-            app_key=app_key,
-            app_secret=app_secret,
-            url=f'{get_comms_session_url()}/oauth2/token',
-            data=data
-        )
-
-    return AccessToken(json_response)
 
 async def get_client_access_token_v2(
         access_token: str,
@@ -71,7 +26,8 @@ async def get_client_access_token_v2(
     Args:
         access_token: Access token to use for authentication.
         session_scope: A list of case-sensitive strings allowing you to control
-            what scope of access the client access token should have.
+            what scope of access the client access token should have. If not specified,
+            the token will possess unrestricted access to all resources and actions.
             The API supports the following scopes:
                 - conf:create: Allows creating a new conference.
                 - notifications:set: Allows the client to subscribe to events.

--- a/client/src/dolbyio_rest_apis/communications/models.py
+++ b/client/src/dolbyio_rest_apis/communications/models.py
@@ -135,6 +135,17 @@ class RemixStatus(dict):
         self.region = get_value_or_default(self, 'region', None)
         self.alias = get_value_or_default(self, 'alias', None)
 
+class RtsStream(dict):
+    """Representation of an RTS Stream start response."""
+
+    def __init__(self, dictionary: dict):
+        dict.__init__(self, dictionary)
+
+        self.stream_name = get_value_or_default(self, 'streamName', None)
+        self.subscribe_token = get_value_or_default(self, 'subscribeToken', None)
+        self.stream_account_id = get_value_or_default(self, 'streamAccountID', None)
+        self.viewer_url = get_value_or_default(self, 'viewerURL', None)
+
 @dataclass
 class Coordinates:
     """Representation of a Coordinate object."""

--- a/client/src/dolbyio_rest_apis/communications/monitor/conferences.py
+++ b/client/src/dolbyio_rest_apis/communications/monitor/conferences.py
@@ -7,7 +7,7 @@ This module contains the functions to work with the monitor API related to confe
 
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
 from dolbyio_rest_apis.communications.monitor.models import GetConferencesResponse, ConferenceSummary, ConferenceStatistics, ConferenceParticipants, ConferenceParticipant
-from dolbyio_rest_apis.core.urls import get_comms_monitor_url
+from dolbyio_rest_apis.core.urls import get_comms_monitor_url_v1
 from typing import Any, Dict, List
 
 async def get_conferences(
@@ -59,7 +59,7 @@ async def get_conferences(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_comms_monitor_url()}/conferences'
+    url = f'{get_comms_monitor_url_v1()}/conferences'
 
     params = {
         'from': tr_from,
@@ -129,7 +129,7 @@ async def get_all_conferences(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_comms_monitor_url()}/conferences'
+    url = f'{get_comms_monitor_url_v1()}/conferences'
 
     params = {
         'from': tr_from,
@@ -187,7 +187,7 @@ async def get_conference(
         HTTPError: If one occurred.
     """
 
-    url = f'{get_comms_monitor_url()}/conferences/{conference_id}'
+    url = f'{get_comms_monitor_url_v1()}/conferences/{conference_id}'
 
     params = {
         'livestats': str(live_stats),
@@ -230,7 +230,7 @@ async def get_conference_statistics(
         HTTPError: If one occurred.
     """
 
-    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/statistics'
+    url = f'{get_comms_monitor_url_v1()}/conferences/{conference_id}/statistics'
 
     async with CommunicationsHttpContext() as http_context:
         json_response = await http_context.requests_get(
@@ -280,7 +280,7 @@ async def get_conference_participants(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/participants'
+    url = f'{get_comms_monitor_url_v1()}/conferences/{conference_id}/participants'
 
     params = {
         'from': tr_from,
@@ -336,7 +336,7 @@ async def get_all_conference_participants(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/participants'
+    url = f'{get_comms_monitor_url_v1()}/conferences/{conference_id}/participants'
 
     params = {
         'from': tr_from,
@@ -415,7 +415,7 @@ async def get_conference_participant(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/participants/{participant_id}'
+    url = f'{get_comms_monitor_url_v1()}/conferences/{conference_id}/participants/{participant_id}'
 
     params = {
         'from': tr_from,

--- a/client/src/dolbyio_rest_apis/communications/monitor/models.py
+++ b/client/src/dolbyio_rest_apis/communications/monitor/models.py
@@ -23,7 +23,7 @@ class ConferenceOwner(dict):
     def __init__(self, dictionary: dict):
         dict.__init__(self, dictionary)
 
-        self.user_id = get_value_or_default(self, 'userID', None)
+        self.user_id = get_value_or_default(self, 'userId', None)
 
         if in_and_not_none(self, 'metadata'):
             self.metadata = UserMetadata(self['metadata'])
@@ -194,71 +194,48 @@ class UserMetadata(dict):
         self.external_photo_url = get_value_or_default(self, 'externalPhotoUrl', None)
         self.ip_address = get_value_or_default(self, 'ipAddress', None)
 
-class RecordingSplit(dict):
-    """Representation of a Recording Split."""
+class ConferenceRecordingMix(dict):
+    """Representation of a Conference Recording Mix."""
 
     def __init__(self, dictionary: dict):
         dict.__init__(self, dictionary)
 
-        self.start_time = get_value_or_default(self, 'startTime', 0)
-        self.duration = get_value_or_default(self, 'duration', 0)
-        self.size = get_value_or_default(self, 'size', 0)
-        self.file_name = get_value_or_default(self, 'fileName', None)
-        self.url = get_value_or_default(self, 'url', None)
+        self.mix_id = get_value_or_default(self, 'mixId', None)
+        self.width = get_value_or_default(self, 'width', -1)
+        self.height = get_value_or_default(self, 'height', -1)
+        self.layout_url = get_value_or_default(self, 'layoutUrl', None)
 
-        if in_and_not_none(self, 'metadata'):
-            self.metadata = UserMetadata(self['metadata'])
-
-class RecordingRecord(dict):
-    """Representation of a Recording Record."""
-
-    def __init__(self, dictionary: dict):
-        dict.__init__(self, dictionary)
-
-        self.start_time = get_value_or_default(self, 'startTime', 0)
-        self.duration = get_value_or_default(self, 'duration', 0)
-        self.size = get_value_or_default(self, 'size', 0)
-        self.file_name = get_value_or_default(self, 'fileName', None)
-        self.url = get_value_or_default(self, 'url', None)
-
-        self.splits = []
-        if in_and_not_none(self, 'splits'):
-            for split in self['splits']:
-                self.splits.append(RecordingSplit(split))
-
-class RecordingAudio(dict):
-    """Representation of a Recording Audio."""
-
-    def __init__(self, dictionary: dict):
-        dict.__init__(self, dictionary)
-
-        self.region = get_value_or_default(self, 'region', None)
-
-        if in_and_not_none(self, 'mix'):
-            self.mix = RecordingMix(self['mix'])
-
-        self.records = []
-        if in_and_not_none(self, 'records'):
-            for record in self['records']:
-                self.records.append(RecordingRecord(record))
-
-class Recording(dict):
-    """Representation of a Recording."""
+class Conference(dict):
+    """Representation of a Conference."""
 
     def __init__(self, dictionary: dict):
         dict.__init__(self, dictionary)
 
         self.conf_id = get_value_or_default(self, 'confId', None)
-        self.alias = get_value_or_default(self, 'alias', None)
-        self.duration = get_value_or_default(self, 'duration', 0)
-        self.ts = get_value_or_default(self, 'ts', 0)
+        self.conf_alias = get_value_or_default(self, 'confAlias', None)
+
+class ConferenceRecording(dict):
+    """Representation of a Conference Recording."""
+
+    def __init__(self, dictionary: dict):
+        dict.__init__(self, dictionary)
+
+        if in_and_not_none(self, 'conference'):
+            self.conference = Conference(self['conference'])
+
+        self.region = get_value_or_default(self, 'region', None)
+        self.url = get_value_or_default(self, 'url', None)
+        self.created_at = get_value_or_default(self, 'createdAt', None)
+        self.recording_type = get_value_or_default(self, 'recordingType', None)
+        self.duration = get_value_or_default(self, 'duration', -1)
+        self.filename = get_value_or_default(self, 'filename', None)
+        self.size = get_value_or_default(self, 'size', -1)
+        self.start_time = get_value_or_default(self, 'startTime', 0)
+        self.media_type = get_value_or_default(self, 'mediaType', None)
         self.region = get_value_or_default(self, 'region', None)
 
         if in_and_not_none(self, 'mix'):
-            self.mix = RecordingMix(self['mix'])
-
-        if in_and_not_none(self, 'audio'):
-            self.audio = RecordingAudio(self['audio'])
+            self.mix = ConferenceRecordingMix(self['mix'])
 
 class GetRecordingsResponse(PagedResponse):
     """Representation of a Recordings response."""
@@ -269,25 +246,23 @@ class GetRecordingsResponse(PagedResponse):
         self.recordings = []
         if in_and_not_none(self, 'recordings'):
             for recording in self['recordings']:
-                self.recordings.append(Recording(recording))
+                self.recordings.append(ConferenceRecording(recording))
 
-class DolbyVoiceRecording(dict):
-    """Representation of a Dolby Voice Recording."""
+class GetConferenceRecordingsResponse(GetRecordingsResponse):
+    """Representation of a Conference Recordings response."""
 
     def __init__(self, dictionary: dict):
-        dict.__init__(self, dictionary)
+        GetRecordingsResponse.__init__(self, dictionary)
 
-        self.region = get_value_or_default(self, 'region', None)
-        self.conf_id = None
-        self.conf_alias = None
         if in_and_not_none(self, 'conference'):
-            self.conf_id = get_value_or_default(self, 'confId', None)
-            self.conf_alias = get_value_or_default(self, 'confAlias', None)
+            self.conference = Conference(self['conference'])
 
-        self.records = []
-        if in_and_not_none(self, 'records'):
-            for record in self['records']:
-                self.records.append(RecordingRecord(record))
+        self.live_conference = get_value_or_default(self, 'liveConference', False)
+
+        self.recordings = []
+        if in_and_not_none(self, 'recordings'):
+            for recording in self['recordings']:
+                self.recordings.append(ConferenceRecording(recording))
 
 class WebHookResponse(dict):
     """Representation of a WebHook event response."""

--- a/client/src/dolbyio_rest_apis/communications/monitor/recordings.py
+++ b/client/src/dolbyio_rest_apis/communications/monitor/recordings.py
@@ -6,54 +6,64 @@ This module contains the functions to work with the monitor API related to recor
 """
 
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
-from dolbyio_rest_apis.communications.monitor.models import GetRecordingsResponse, Recording, DolbyVoiceRecording
-from dolbyio_rest_apis.core.urls import get_comms_monitor_url
+from dolbyio_rest_apis.communications.monitor.models import GetConferenceRecordingsResponse
+from dolbyio_rest_apis.communications.monitor.models import GetRecordingsResponse, ConferenceRecording
+from dolbyio_rest_apis.core.urls import get_comms_monitor_url_v2
 from typing import Any, List
 
 async def get_recordings(
         access_token: str,
+        region: str=None,
+        media_type: str=None,
+        recording_type: str=None,
         tr_from: int=0,
         tr_to: int=9999999999999,
-        maximum: int=100,
+        page_size: int=100,
         start: str=None,
-        perm: bool=False,
     ) -> GetRecordingsResponse:
     r"""
-    Get recording details
-
-    Get a list of the recorded conference metadata, such as duration or size of the recording.
+    Gets a list of the recorded conference metadata, such as duration or size of the recording.
     This API checks only the recordings that have ended during a specific time range.
     Recordings are indexed based on the ending time.
+
+    This API returns presigned URLs for secure download of the recording files.
+    The URL returned in the response is an AWS S3 presigned URL with a validity of ten minutes.
 
     See: https://docs.dolby.io/communications-apis/reference/get-recordings
 
     Args:
         access_token: Access token to use for authentication.
-        tr_from: The beginning of the time range (in milliseconds that have elapsed since epoch).
-        tr_to: The end of the time range (in milliseconds that have elapsed since epoch).
-        maximum: The maximum number of displayed results.
-            We recommend setting the proper value of this parameter to shorten the response time.
-        start: When the results span multiple pages, use this option to navigate through pages.
+        region: (Optional) The region code in which the mix recording took place.
+        media_type: (Optional) The media type of the recordings to return, 'audio/mpeg' or 'video/mp4'.
+        recording_type: (Optional) The type of the recordings to return, 'mix' or 'participant'.
+        tr_from: (Optional) The beginning of the time range (in milliseconds that have elapsed since epoch).
+        tr_to: (Optional) The end of the time range (in milliseconds that have elapsed since epoch).
+        page_size: (Optional) Number of elements to return per page.
+        start: (Optional) When the results span multiple pages, use this option to navigate through pages.
             By default, only the max number of results is displayed. To see the next results,
             set the start parameter to the value of the next key returned in the previous response.
-        perm: When set to true, the URL is replaced with a monitor API signed URL with unlimited validity.
 
     Returns:
-        A :class:`GetRecordingsResponse` object.
+        A :class:`GetRecordingsV2Response` object.
 
     Raises:
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_comms_monitor_url()}/recordings'
+    url = f'{get_comms_monitor_url_v2()}/recordings'
 
     params = {
         'from': tr_from,
         'to': tr_to,
-        'max': maximum,
-        'perm': str(perm).lower(),
+        'max': page_size,
     }
 
+    if not region is None:
+        params['region'] = region
+    if not media_type is None:
+        params['mediaType'] = media_type
+    if not recording_type is None:
+        params['type'] = recording_type
     if not start is None:
         params['start'] = start
 
@@ -68,42 +78,53 @@ async def get_recordings(
 
 async def get_all_recordings(
         access_token: str,
+        region: str=None,
+        media_type: str=None,
+        recording_type: str=None,
         tr_from: int=0,
         tr_to: int=9999999999999,
         page_size: int=100,
-        perm: bool=False,
-    ) -> List[Recording]:
+    ) -> List[ConferenceRecording]:
     r"""
-    Get all recording details
-
-    Get a list of all the recorded conference metadata, such as duration or size of the recording.
+    Gets a list of all the recorded conference metadata, such as duration or size of the recording.
     This API checks only the recordings that have ended during a specific time range.
     Recordings are indexed based on the ending time.
+
+    This API returns presigned URLs for secure download of the recording files.
+    The URL returned in the response is an AWS S3 presigned URL with a validity of ten minutes.
 
     See: https://docs.dolby.io/communications-apis/reference/get-recordings
 
     Args:
         access_token: Access token to use for authentication.
-        tr_from: The beginning of the time range (in milliseconds that have elapsed since epoch).
-        tr_to: The end of the time range (in milliseconds that have elapsed since epoch).
+        region: (Optional) The region code in which the mix recording took place.
+        media_type: (Optional) The media type of the recordings to return, 'audio/mpeg' or 'video/mp4'.
+        recording_type: (Optional) The type of the recordings to return, 'mix' or 'participant'.
+        tr_from: (Optional) The beginning of the time range (in milliseconds that have elapsed since epoch).
+        tr_to: (Optional) The end of the time range (in milliseconds that have elapsed since epoch).
         page_size: (Optional) Number of elements to return per page.
-        perm: When set to true, the URL is replaced with a monitor API signed URL with unlimited validity.
 
     Returns:
-        A list of :class:`Recording` objects.
+        A list of :class:`ConferenceRecording` objects.
 
     Raises:
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_comms_monitor_url()}/recordings'
+    url = f'{get_comms_monitor_url_v2()}/recordings'
 
     params = {
         'from': tr_from,
         'to': tr_to,
         'max': page_size,
-        'perm': str(perm).lower(),
     }
+
+    if not region is None:
+        params['region'] = region
+    if not media_type is None:
+        params['mediaType'] = media_type
+    if not recording_type is None:
+        params['type'] = recording_type
 
     recordings = []
 
@@ -116,53 +137,121 @@ async def get_all_recordings(
             page_size=page_size
         )
 
-    recordings: List[Recording] = []
+    recordings: List[ConferenceRecording] = []
     for element in elements:
-        recording = Recording(element)
+        recording = ConferenceRecording(element)
         recordings.append(recording)
 
     return recordings
 
-async def get_recording(
+async def get_conference_recordings(
         access_token: str,
         conference_id: str,
+        media_type: str=None,
+        recording_type: str=None,
         tr_from: int=0,
         tr_to: int=9999999999999,
         page_size: int=100,
-        perm: bool=False,
-    ) -> GetRecordingsResponse:
+        start: str=None,
+    ) -> GetConferenceRecordingsResponse:
     r"""
-    Get the recording of a specific conference
+    Gets a list of the recorded conference metadata, such as duration or size of the recording.
 
-    Get a list of the recorded conference metadata, such as duration or size of the recording.
-    This API checks the recordings that have ended during a specific time range.
+    This API checks only the recordings that have ended during a specific time range.
     Recordings are indexed based on the ending time.
+
+    This API returns presigned URLs for secure download of the recording files.
+    The URL returned in the response is an AWS S3 presigned URL with a validity of ten minutes.
 
     See: https://docs.dolby.io/communications-apis/reference/get-conference-recordings
 
     Args:
         access_token: Access token to use for authentication.
         conference_id: Identifier of the conference.
-        tr_from: The beginning of the time range (in milliseconds that have elapsed since epoch).
-        tr_to: The end of the time range (in milliseconds that have elapsed since epoch).
+        media_type: (Optional) The media type of the recordings to return, 'audio/mpeg' or 'video/mp4'.
+        recording_type: (Optional) The type of the recordings to return, 'mix' or 'participant'.
+        tr_from:(Optional)  The beginning of the time range (in milliseconds that have elapsed since epoch).
+        tr_to: (Optional) The end of the time range (in milliseconds that have elapsed since epoch).
         page_size: (Optional) Number of elements to return per page.
-        perm: When set to true, the URL is replaced with a monitor API signed URL with unlimited validity.
 
     Returns:
-        A :class:`GetRecordingsResponse` object.
+        A :class:`GetConferenceRecordingsResponse` object.
 
     Raises:
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/recordings'
+    url = f'{get_comms_monitor_url_v2()}/conferences/{conference_id}/recordings'
 
     params = {
         'from': tr_from,
         'to': tr_to,
         'max': page_size,
-        'perm': str(perm).lower(),
     }
+
+    if not media_type is None:
+        params['mediaType'] = media_type
+    if not recording_type is None:
+        params['type'] = recording_type
+    if not start is None:
+        params['start'] = start
+
+    async with CommunicationsHttpContext() as http_context:
+        json_response = await http_context.requests_get(
+            access_token=access_token,
+            url=url,
+            params=params,
+        )
+
+    return GetConferenceRecordingsResponse(json_response)
+
+async def get_all_conference_recordings(
+        access_token: str,
+        conference_id: str,
+        media_type: str=None,
+        recording_type: str=None,
+        tr_from: int=0,
+        tr_to: int=9999999999999,
+        page_size: int=100,
+    ) -> List[ConferenceRecording]:
+    r"""
+    Gets a list of all the recorded conference metadata, such as duration or size of the recording.
+
+    This API checks only the recordings that have ended during a specific time range.
+    Recordings are indexed based on the ending time.
+
+    This API returns presigned URLs for secure download of the recording files.
+    The URL returned in the response is an AWS S3 presigned URL with a validity of ten minutes.
+
+    See: https://docs.dolby.io/communications-apis/reference/get-conference-recordings
+
+    Args:
+        access_token: Access token to use for authentication.
+        conference_id: Identifier of the conference.
+        media_type: (Optional) The media type of the recordings to return, 'audio/mpeg' or 'video/mp4'.
+        recording_type: (Optional) The type of the recordings to return, 'mix' or 'participant'.
+        tr_from:(Optional)  The beginning of the time range (in milliseconds that have elapsed since epoch).
+        tr_to: (Optional) The end of the time range (in milliseconds that have elapsed since epoch).
+        page_size: (Optional) Number of elements to return per page.
+
+    Returns:
+        A list of :class:`ConferenceRecording` objects.
+
+    Raises:
+        HttpRequestError: If a client error one occurred.
+        HTTPError: If one occurred.
+    """
+    url = f'{get_comms_monitor_url_v2()}/conferences/{conference_id}/recordings'
+
+    params = {
+        'from': tr_from,
+        'to': tr_to,
+    }
+
+    if not media_type is None:
+        params['mediaType'] = media_type
+    if not recording_type is None:
+        params['type'] = recording_type
 
     recordings = []
 
@@ -175,9 +264,9 @@ async def get_recording(
             page_size=page_size
         )
 
-    recordings: List[Recording] = []
+    recordings: List[ConferenceRecording] = []
     for element in elements:
-        recording = Recording(element)
+        recording = ConferenceRecording(element)
         recordings.append(recording)
 
     return recordings
@@ -203,45 +292,10 @@ async def delete_recording(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-
-    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/recordings'
+    url = f'{get_comms_monitor_url_v2()}/conferences/{conference_id}/recordings'
 
     async with CommunicationsHttpContext() as http_context:
         await http_context.requests_delete(
             access_token=access_token,
             url=url,
         )
-
-async def get_dolby_voice_recordings(
-        access_token: str,
-        conference_id: str,
-    ) -> DolbyVoiceRecording:
-    r"""
-    Get Dolby Voice audio recordings of a conference
-
-    Get details of all Dolby Voice-based audio recordings, and associated split recordings,
-    for a given conference and download the conference recording in the MP3 audio format.
-
-    See: https://docs.dolby.io/communications-apis/reference/get-dolby-voice-audio-recordings
-
-    Args:
-        access_token: Access token to use for authentication.
-        conference_id: Identifier of the conference.
-
-    Returns:
-        A :class:`DolbyVoiceRecording` object.
-
-    Raises:
-        HttpRequestError: If a client error one occurred.
-        HTTPError: If one occurred.
-    """
-
-    url = f'{get_comms_monitor_url()}/conferences/{conference_id}/recordings/audio'
-
-    async with CommunicationsHttpContext() as http_context:
-        json_response = await http_context.requests_get(
-            access_token=access_token,
-            url=url,
-        )
-
-    return DolbyVoiceRecording(json_response)

--- a/client/src/dolbyio_rest_apis/communications/monitor/webhooks.py
+++ b/client/src/dolbyio_rest_apis/communications/monitor/webhooks.py
@@ -7,7 +7,7 @@ This module contains the functions to work with the monitor API related to webho
 
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
 from dolbyio_rest_apis.communications.monitor.models import GetWebHookResponse, WebHook
-from dolbyio_rest_apis.core.urls import get_comms_monitor_url
+from dolbyio_rest_apis.core.urls import get_comms_monitor_url_v1
 from typing import Any, List
 
 async def get_events(
@@ -45,7 +45,7 @@ async def get_events(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_comms_monitor_url()}/'
+    url = f'{get_comms_monitor_url_v1()}/'
     if not conference_id is None:
         url += f'conferences/{conference_id}/'
     url += 'webhooks'
@@ -100,7 +100,7 @@ async def get_all_events(
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
-    url = f'{get_comms_monitor_url()}/'
+    url = f'{get_comms_monitor_url_v1()}/'
     if not conference_id is None:
         url += f'conferences/{conference_id}/'
     url += 'webhooks'

--- a/client/src/dolbyio_rest_apis/communications/recording.py
+++ b/client/src/dolbyio_rest_apis/communications/recording.py
@@ -13,23 +13,41 @@ async def start(
         access_token: str,
         conference_id: str,
         layout_url: str=None,
+        width: int=-1,
+        height: int=-1,
+        mix_id: str=None,
     ) -> None:
     r"""
     Starts recording for the specified conference.
-    You can specify a custom layout URL per recording request.
-    The `layoutURL` parameter overrides the layout URL configured in the dashboard.
+
+    You can specify a custom layout URL per a recording request.
+    The `layout_url` parameter overrides the layout URL configured in the dashboard.
+
+    You can also specify the resolution of the recording.
+    The default mixer layout application supports both 1920x1080 (16:9 aspect ratio) and 1080x1920 (9:16 aspect ratio).
+    If the `width` and `height` parameters are not specified, then the system defaults to 1920x1080.
+
+    Using the `mix_id` parameter you can uniquely identify individual mixed recordings.
+    For example, `landscape-stage` and `portrait-audience` as mixId can help you identify the purpose of the recording
+    when you receive the webhook notification or use the Monitor API to retrieve the recordings.
+    You may start only one recording per mixId.
 
     See: https://docs.dolby.io/communications-apis/reference/api-recording-start
 
     Args:
         access_token: Access token to use for authentication.
         conference_id: Identifier of the conference.
-        layout_url: Overwrites the layout URL configuration.
+        layout_url: (Optional) Overwrites the layout URL configuration.
             This field is ignored if it is not relevant regarding recording configuration,
             for example if live_recording set to false or if the recording is MP3 only.
             - `null`: uses the layout URL configured in the dashboard (if no URL is set in the dashboard, then uses the Dolby.io default);
             - `default`: uses the Dolby.io default layout;
             - URL string: uses this layout URL
+        width: (Optional) The frame width can range between 390 and 1920 pixels and is set to 1920 by default.
+        height: (Optional) The frame height can range between 390 and 1920 pixels and is set to 1080 by default.
+        mix_id: (Optional) A unique identifier for you to identify individual mixes.
+            You may only start one streaming per mixId.
+            Not providing its value results in setting the `default` value.
 
     Raises:
         HttpRequestError: If a client error one occurred.
@@ -39,6 +57,11 @@ async def start(
 
     payload = {}
     add_if_not_none(payload, 'layoutUrl', layout_url)
+    if width > 0:
+        payload['width'] = width
+    if height > 0:
+        payload['height'] = height
+    add_if_not_none(payload, 'mixId', mix_id)
 
     async with CommunicationsHttpContext() as http_context:
         await http_context.requests_post(

--- a/client/src/dolbyio_rest_apis/communications/remix.py
+++ b/client/src/dolbyio_rest_apis/communications/remix.py
@@ -48,7 +48,6 @@ async def start(
             You may only start one streaming per mixId.
             Not providing its value results in setting the `default` value.
 
-
     Returns:
         A :class:`RemixStatus` object that represents the status of the remix.
 

--- a/client/src/dolbyio_rest_apis/communications/remix.py
+++ b/client/src/dolbyio_rest_apis/communications/remix.py
@@ -14,27 +14,40 @@ async def start(
         access_token: str,
         conference_id: str,
         layout_url: str=None,
-        layout_name: str=None,
+        width: int=-1,
+        height: int=-1,
+        mix_id: str=None,
     ) -> RemixStatus:
     r"""
     Remix a conference.
 
-    Use this API to trigger a remix and regenerate a recording of a previously recorded conference using
-    the current mixer layout. The `Recording.MP4.Available` event is sent if the customer has configured
-    the webhook in the developer portal.
+    Triggers a remix and regenerates a recording of a previously recorded conference
+    using a [mixer layout](https://docs.dolby.io/communications-apis/docs/guides-mixer-layout).
+    You can remix only one conference at a time.
+    The `Recordings.Available` event is sent if the customer has configured the webhook in the developer portal.
+    For more information, see the [Recording Conferences](https://docs.dolby.io/communications-apis/docs/guides-recording-conferences)
+    and [Multiple Layout Mixes](https://docs.dolby.io/communications-apis/docs/guides-multiple-layout-mixes) documents.
+    
+    You can also specify the resolution of the remix.
+    The default mixer layout application supports both 1920x1080 (16:9 aspect ratio) and 1080x1920 (9:16 aspect ratio).
+    If the `width` and `height` parameters are not specified, then the system defaults to 1920x1080.
 
     See: https://docs.dolby.io/communications-apis/reference/start-conference-remix
 
     Args:
         access_token: Access token to use for authentication.
         conference_id: Identifier of the conference.
-        layout_url: Overwrites the layout URL configuration:
+        layout_url: (Optional) Overwrites the layout URL configuration:
             null: uses the layout URL configured in the dashboard
                 (if no URL is set in the dashboard, then uses the Dolby.io default)
             default: uses the Dolby.io default layout
             URL string: uses this layout URL
-        layout_name: Defines a name for the given layout URL, which makes layout identification
-            easier for customers especially when the layout URL is not explicit.
+        width: (Optional) The frame width can range between 390 and 1920 pixels and is set to 1920 by default.
+        height: (Optional) The frame height can range between 390 and 1920 pixels and is set to 1080 by default.
+        mix_id: (Optional) A unique identifier for you to identify individual mixes.
+            You may only start one streaming per mixId.
+            Not providing its value results in setting the `default` value.
+
 
     Returns:
         A :class:`RemixStatus` object that represents the status of the remix.
@@ -47,7 +60,11 @@ async def start(
 
     payload = {}
     add_if_not_none(payload, 'layoutUrl', layout_url)
-    add_if_not_none(payload, 'layoutName', layout_name)
+    if width > 0:
+        payload['width'] = width
+    if height > 0:
+        payload['height'] = height
+    add_if_not_none(payload, 'mixId', mix_id)
 
     async with CommunicationsHttpContext() as http_context:
         json_response = await http_context.requests_post(

--- a/client/src/dolbyio_rest_apis/communications/streaming.py
+++ b/client/src/dolbyio_rest_apis/communications/streaming.py
@@ -8,6 +8,7 @@ This module contains the functions to work with the streaming API.
 from dolbyio_rest_apis.communications.internal.http_context import CommunicationsHttpContext
 from dolbyio_rest_apis.core.helpers import add_if_not_none
 from dolbyio_rest_apis.core.urls import get_comms_url_v2
+from .models import RtsStream
 
 async def start_rtmp(
         access_token: str,
@@ -97,7 +98,7 @@ async def start_rts(
         width: int=-1,
         height: int=-1,
         mix_id: str=None,
-    ) -> None:
+    ) -> RtsStream:
     r"""
     Starts real-time streaming using Dolby.io Real-time Streaming services (formerly Millicast).
     
@@ -122,6 +123,9 @@ async def start_rts(
         mix_id: (Optional) A unique identifier for you to identify individual mixes.
             You may only start one streaming per mixId.
             Not providing its value results in setting the `default` value.
+
+    Returns:
+        A :class:`RtsStream` object that represents the status of the remix.
 
     Raises:
         HttpRequestError: If a client error one occurred.

--- a/client/src/dolbyio_rest_apis/communications/streaming.py
+++ b/client/src/dolbyio_rest_apis/communications/streaming.py
@@ -14,11 +14,17 @@ async def start_rtmp(
         conference_id: str,
         rtmp_url: str,
         layout_url: str=None,
-        layout_name: str=None,
+        width: int=-1,
+        height: int=-1,
+        mix_id: str=None,
     ) -> None:
     r"""
     Starts the RTMP live stream for the specified conference. Once the Dolby.io Communications APIs service starts
     streaming to the target url, a `Stream.Rtmp.InProgress` Webhook event will be sent.
+    
+    You can also specify the resolution of the RTMP stream.
+    The default mixer layout application supports both 1920x1080 (16:9 aspect ratio) and 1080x1920 (9:16 aspect ratio).
+    If the `width` and `height` parameters are not specified, then the system defaults to 1920x1080.
 
     See: https://docs.dolby.io/communications-apis/reference/start-rtmp
 
@@ -26,14 +32,17 @@ async def start_rtmp(
         access_token: Access token to use for authentication.
         conference_id: Identifier of the conference.
         rtmp_url: The destination URI provided by the RTMP service.
-        layout_url: Overwrites the layout URL configuration.
+        layout_url: (Optional) Overwrites the layout URL configuration.
             This field is ignored if it is not relevant regarding recording configuration,
             for example if live_recording set to false or if the recording is MP3 only.
             - `null`: uses the layout URL configured in the dashboard (if no URL is set in the dashboard, then uses the Dolby.io default);
             - `default`: uses the Dolby.io default layout;
             - URL string: uses this layout URL
-        layout_name: Defines a name for the given layout URL, which makes layout identification
-            easier for customers especially when the layout URL is not explicit.
+        width: (Optional) The frame width can range between 390 and 1920 pixels and is set to 1920 by default.
+        height: (Optional) The frame height can range between 390 and 1920 pixels and is set to 1080 by default.
+        mix_id: (Optional) A unique identifier for you to identify individual mixes.
+            You may only start one streaming per mixId.
+            Not providing its value results in setting the `default` value.
 
     Raises:
         HttpRequestError: If a client error one occurred.
@@ -44,7 +53,11 @@ async def start_rtmp(
         'uri': rtmp_url,
     }
     add_if_not_none(payload, 'layoutUrl', layout_url)
-    add_if_not_none(payload, 'layoutName', layout_name)
+    if width > 0:
+        payload['width'] = width
+    if height > 0:
+        payload['height'] = height
+    add_if_not_none(payload, 'mixId', mix_id)
 
     async with CommunicationsHttpContext() as http_context:
         await http_context.requests_post(
@@ -80,13 +93,17 @@ async def stop_rtmp(
 async def start_rts(
         access_token: str,
         conference_id: str,
-        stream_name: str,
-        publishing_token: str,
         layout_url: str=None,
-        layout_name: str=None,
+        width: int=-1,
+        height: int=-1,
+        mix_id: str=None,
     ) -> None:
     r"""
     Starts real-time streaming using Dolby.io Real-time Streaming services (formerly Millicast).
+    
+    You can also specify the resolution of the RTS stream.
+    The default mixer layout application supports both 1920x1080 (16:9 aspect ratio) and 1080x1920 (9:16 aspect ratio).
+    If the `width` and `height` parameters are not specified, then the system defaults to 1920x1080.
 
     See: https://docs.dolby.io/communications-apis/reference/start-rts
 
@@ -95,25 +112,29 @@ async def start_rts(
         conference_id: Identifier of the conference.
         stream_name: The Dolby.io Real-time Streaming stream name to which the conference is broadcasted.
         publishing_token: The publishing token used to identify the broadcaster.
-        layout_url: Overwrites the layout URL configuration:
+        layout_url: (Optional) Overwrites the layout URL configuration:
             null: uses the layout URL configured in the dashboard
                 (if no URL is set in the dashboard, then uses the Dolby.io default)
             default: uses the Dolby.io default layout
             URL string: uses this layout URL
-        layout_name: Defines a name for the given layout URL, which makes layout identification
-            easier for customers especially when the layout URL is not explicit.
+        width: (Optional) The frame width can range between 390 and 1920 pixels and is set to 1920 by default.
+        height: (Optional) The frame height can range between 390 and 1920 pixels and is set to 1080 by default.
+        mix_id: (Optional) A unique identifier for you to identify individual mixes.
+            You may only start one streaming per mixId.
+            Not providing its value results in setting the `default` value.
 
     Raises:
         HttpRequestError: If a client error one occurred.
         HTTPError: If one occurred.
     """
 
-    payload = {
-        'stream_name': stream_name,
-        'publishingToken': publishing_token,
-    }
+    payload = {}
     add_if_not_none(payload, 'layoutUrl', layout_url)
-    add_if_not_none(payload, 'layoutName', layout_name)
+    if width > 0:
+        payload['width'] = width
+    if height > 0:
+        payload['height'] = height
+    add_if_not_none(payload, 'mixId', mix_id)
 
     async with CommunicationsHttpContext() as http_context:
         await http_context.requests_post(

--- a/client/src/dolbyio_rest_apis/core/urls.py
+++ b/client/src/dolbyio_rest_apis/core/urls.py
@@ -6,12 +6,8 @@ This module contains the URLs to use to call the REST APIs.
 """
 
 API_URL = 'api.dolby.io'
-
 COMMS_URL = 'comms.api.dolby.io'
-COMMS_SESSION_URL = 'session.voxeet.com'
-
 SAPI_URL = 'api.millicast.com'
-
 MAPI_URL = 'api.dolby.com'
 
 def get_api_url() -> str:
@@ -20,16 +16,16 @@ def get_api_url() -> str:
 def get_comms_url_v1() -> str:
     return f'https://{COMMS_URL}/v1'
 
-def get_comms_monitor_url() -> str:
-    return f'{get_comms_url_v1()}/monitor'
-
 def get_comms_url_v2(region: str = None) -> str:
     if region is None:
         return f'https://{COMMS_URL}/v2'
     return f'https://{region}.{COMMS_URL}/v2'
 
-def get_comms_session_url() -> str:
-    return f'https://{COMMS_SESSION_URL}/v1'
+def get_comms_monitor_url_v1() -> str:
+    return f'{get_comms_url_v1()}/monitor'
+
+def get_comms_monitor_url_v2() -> str:
+    return f'{get_comms_url_v2()}/monitor'
 
 def get_rts_url() -> str:
     return f'https://{SAPI_URL}'


### PR DESCRIPTION
In `dolbyio_rest_apis.communications.monitor.recordings`:
* https://docs.dolby.io/communications-apis/reference/get-recordings
* Update `get_recordings` to new API endpoint
* Update `get_all_recordings` to new API endpoint
* Replace `get_recording` by `get_conference_recordings`
* Add `get_all_conference_recordings`
* Remove `get_dolby_voice_recordings`, `download_mp4_recording`, `download_mp3_recording`

In `dolbyio_rest_apis.communications.recording`:
* https://docs.dolby.io/communications-apis/reference/api-recording-start
* Update the `start` with new API parameters

In `dolbyio_rest_apis.communications.remix`:
* https://docs.dolby.io/communications-apis/reference/start-conference-remix
* Update the `start` with new API parameters and remove the `layout_name`.

In `dolbyio_rest_apis.communications.streaming`:
* https://docs.dolby.io/communications-apis/reference/start-rtmp
* Update the `start_rtmp` with new API parameters and remove the `layout_name`.
* Update the `start_rts` with new API parameters and remove the `layout_name`.

In `dolbyio_rest_apis.communications.authentication`:
* Remove deprecated `get_client_access_token`